### PR TITLE
fix build without openmp

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,7 +14,7 @@ openmp   = "-fopenmp"
     println("Disabling OpenMP. To force enable OpenMP, set MOCHA_FORCE_OMP environment")
     println("variable.")
     println("")
-    openmp = ""
+    openmp = ()
   end
 end : nothing
 


### PR DESCRIPTION
Interpolating `""` into the `cmd` leads to the following:

```jl
Running `g++ -fPIC -Wall -O3 -shared '' -o libmochaext.so im2col.cpp pooling.cpp`
g++: error: : No such file or directory
```
Setting `openmp = ()` interpolates to:
```jl
g++ -fPIC -Wall -O3 -shared -o libmochaext.so im2col.cpp pooling.cpp
```
