### PR TITLE
De-convolution layer

### DIFF
--- a/src/layers/convolution.jl
+++ b/src/layers/convolution.jl
@@ -131,17 +131,17 @@ type ConvolutionLayerState <: LayerState
       blobs_diff[i] = make_blob(backend, dtype, state.width_out, state.height_out, layer.n_filter, batch_size)
     end
 
+    filter_dims = tuple(layer.kernel...,div(state.conv_chann_in,layer.n_group),state.conv_chann_out)
     if shared_params != nothing
       @assert length(shared_params) == 2
       @assert shared_params[1].name == "filter" && shared_params[2].name == "bias"
-      @assert size(shared_params[1].blob) == tuple(layer.kernel...,div(channels,layer.n_group),layer.n_filter)
+      @assert size(shared_params[1].blob) == filter_dims
       @assert eltype(shared_params[1].blob) == dtype
       @debug("ConvolutionLayer($(layer.name)): sharing filters and bias")
 
       param_filter, param_bias = [share_parameter(backend, param) for param in shared_params]
     else
-      param_filter = make_parameter(backend,"filter",dtype,(layer.kernel[1],layer.kernel[2],
-          div(channels,layer.n_group), layer.n_filter),
+      param_filter = make_parameter(backend,"filter",dtype, filter_dims,
           layer.filter_init, layer.filter_regu, layer.filter_cons, layer.filter_lr)
       param_bias   = make_parameter(backend,"bias",dtype,(layer.n_filter,),
           layer.bias_init, layer.bias_regu, layer.bias_cons, layer.bias_lr)
@@ -241,10 +241,9 @@ function conv_fwd_impl(backend::CPUBackend, state::ConvolutionLayerState, input:
       col_buffer = convert(Ptr{state.dtype}, col_buffer)
     end
 
-    filter_trans = state.layer.deconv ? 'T' : 'N'
     output_ptr = convert(Ptr{state.dtype}, output.data) + top_img_offset * (n-1)
     for g = 1:state.layer.n_group
-      RawBLAS.gemm!('N', filter_trans, state.conv_out_sp, div(state.conv_chann_out, state.layer.n_group),
+      RawBLAS.gemm!('N', 'N', state.conv_out_sp, div(state.conv_chann_out, state.layer.n_group),
           div(state.kernel_dim, state.layer.n_group),
           convert(state.dtype, 1), col_buffer + state.col_offset * (g-1),
           convert(Ptr{state.dtype}, pointer(state.filter.data)) + state.weight_offset * (g-1),
@@ -269,9 +268,8 @@ function conv_bwd_impl(backend::CPUBackend, state::ConvolutionLayerState, top_di
       col_buffer = convert(Ptr{state.dtype}, state.etc.col_buffer.data)
     end
 
-    filter_trans = state.layer.deconv ? 'N' : 'T'
     for g = 1:state.layer.n_group
-      RawBLAS.gemm!('N', filter_trans, state.conv_out_sp, div(state.kernel_dim, state.layer.n_group),
+      RawBLAS.gemm!('N', 'T', state.conv_out_sp, div(state.kernel_dim, state.layer.n_group),
           div(state.conv_chann_out, state.layer.n_group),
           convert(state.dtype, 1), top_diff_ptr + state.output_offset * (g-1),
           convert(Ptr{state.dtype}, state.filter.data) + state.weight_offset * (g-1),
@@ -344,12 +342,12 @@ function backward(backend::CPUBackend, state::ConvolutionLayerState, inputs::Vec
           end
           for g = 1:state.layer.n_group
             RawBLAS.gemm!('T', 'N',
-                div(state.conv_chann_out, state.layer.n_group),
                 div(state.kernel_dim, state.layer.n_group),
+                div(state.conv_chann_out, state.layer.n_group),
                 state.conv_out_sp,
                 one(state.dtype),
-                input_ptr + state.output_offset * (g-1),
                 col_buffer + state.col_offset * (g-1),
+                input_ptr + state.output_offset * (g-1),
                 one(state.dtype),
                 convert(Ptr{state.dtype}, pointer(state.∇filter.data)) + state.weight_offset * (g-1))
           end
@@ -364,9 +362,12 @@ function backward(backend::CPUBackend, state::ConvolutionLayerState, inputs::Vec
           end
           for g = 1:state.layer.n_group
             RawBLAS.gemm!('T', 'N',
-                div(state.kernel_dim, state.layer.n_group), div(state.conv_chann_out, state.layer.n_group),
-                state.conv_out_sp, convert(state.dtype, 1), col_buffer + state.col_offset * (g-1),
-                top_diff_ptr + state.output_offset * (g-1), convert(state.dtype, 1),
+                div(state.kernel_dim, state.layer.n_group),
+                div(state.conv_chann_out, state.layer.n_group),
+                state.conv_out_sp, convert(state.dtype, 1),
+                col_buffer + state.col_offset * (g-1),
+                top_diff_ptr + state.output_offset * (g-1),
+                one(state.dtype),
                 convert(Ptr{state.dtype}, pointer(state.∇filter.data)) + state.weight_offset * (g-1))
           end
         end

--- a/src/layers/convolution.md
+++ b/src/layers/convolution.md
@@ -22,6 +22,8 @@ im2col(img) x filter => img_out: (w_out, h_out) x (n_filter)
 
 ∂img_out x Tr(filter) => ∂(im2col(img))
 
+Tr(im2col(img)) x ∂img_out => ∂filter
+
 ## Deconvolution
 
 ### Deconvolution Forward
@@ -32,6 +34,7 @@ img x Tr(filter) => im2col(img_out): (w,h) x (kernel_w,kernel_h,n_filter)
 
 im2col(∂img_out) x filter => ∂img: (w,h) x chann
 
+Tr(im2col(∂img_out)) x img => ∂filter: (kernel_w,kernel_h,n_filter) x (chann)
 
 
 

--- a/src/layers/convolution.md
+++ b/src/layers/convolution.md
@@ -1,0 +1,72 @@
+# Implementation Notes of convolution/deconvolution via im2col/col2im
+
+## Tensor shapes
+
+Filter tensor
+
+* convolution: (kernel_w, kernel_h, chann) x (n_filter)
+* deconvolution: (kernel_w, kernel_h, n_filter) x (chann)
+
+Col-buffer
+
+* convolution: (w_out, h_out) x (kernel_w,kernel_h, chann)
+* deconvolution: (w, h) x (kernel_w,kernel_h, n_filter)
+
+## Convolution
+
+### Convolution Forward
+
+im2col(img) x filter => img_out: (w_out, h_out) x (n_filter)
+
+### Convolution Backward
+
+∂img_out x Tr(filter) => ∂(im2col(img))
+
+## Deconvolution
+
+### Deconvolution Forward
+
+img x Tr(filter) => im2col(img_out): (w,h) x (kernel_w,kernel_h,n_filter)
+
+### Deconvolution Backward
+
+im2col(∂img_out) x filter => ∂img: (w,h) x chann
+
+
+
+
+# Situation with groups
+
+## Tensor shapes
+
+Filter tensor
+
+* convolution: (kernel_w, kernel_h, chann/n_grp) x (n_filter)
+* deconvolution: (kernel_w, kernel_h, n_filter/n_grp) x (chann)
+
+Col-buffer
+
+* convolution: (w_out, h_out) x (kernel_w,kernel_h, chann/n_grp)
+* deconvolution: (w,h) x (kernel_w,kernel_h,n_filter/n_grp)
+
+When allocating we do not divide by n_grp because im2col/col2im are done per-image instead of per-group.
+
+## Convolution
+
+### Convolution Forward
+
+im2col(img<grp>) x filter<grp> => img_out<grp>: (w_out,h_out) x (n_filter/n_grp)
+
+### Convolution Backward
+
+∂img_out<grp> x Tr(filter<grp>) => ∂(im2col(img<grp>))
+
+## Deconvolution
+
+### Deconvolution Forward
+
+img<grp> x Tr(filter<grp>) => im2col(img_out<grp>): (w,h) x (kernel_w,kernel_h,n_filter/n_grp)
+
+### Deconvolution Backward
+
+im2col(∂img_out<grp>) x filter<grp> => ∂img<grp>: (w,h) x (chann/n_grp)

--- a/test/layers/convolution.jl
+++ b/test/layers/convolution.jl
@@ -250,7 +250,7 @@ end
 
 function test_convolution_layer(backend::Backend)
   test_convolution_layer(backend, 3, Float64, 1e-10)
-  test_convolution_layer(backend, 3, Float32, 1e-2) # Float32 is sooo inaccurate?
+  test_convolution_layer(backend, 3, Float32, 1e-1) # Float32 is sooo inaccurate?
 end
 if test_cpu
   test_convolution_layer(backend_cpu)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ function test_dir(dir)
     include("$dir/$file")
   end
 end
+test_dir("layers")
 
 ############################################################
 # Network

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,15 @@ if test_gpu
   init(backend_gpu)
 end
 
+# a wrapper to rand, make simple random numbers
+# with only a few effective digit after the decimal
+# point, making it easier when one need to do
+# manual calculation to debug
+function simplerand(args...)
+  ret = rand(args...)
+  round(ret*100)/100
+end
+
 # run test in the whole directory, latest modified files
 # are run first, this makes waiting time shorter when writing
 # or modifying unit-tests


### PR DESCRIPTION
This is a working in process PR to address #46. Basically this add an option to the `ConvolutionLayer` to allow it perform _de-convolution_ instead. A _de-convolution_ is conceptually like a "inverted" convolution layer, or could also be thought as a convolution layer with fractional stride. See http://arxiv.org/abs/1411.4038 for more details. The Caffe model definition for the mentioned paper could be found [here](https://gist.github.com/longjon/d24098e083bec05e456e#file-readme-md), including pointer to an implementation of deconvolution in Caffe (not merged into the official Caffe repo yet).
