### PR TITLE
Proposed Change to TrainingSummary()

### DIFF
--- a/docs/user-guide/solver.rst
+++ b/docs/user-guide/solver.rst
@@ -229,19 +229,34 @@ Built-in Coffee Breaks
    iteration is reported by default. You can also call the function with the following
    named parameters in order to customize the output:
 
-   .. attribute:: showIter(=true)
+   .. attribute:: show_iter(=true)
    Shows the current iteration number.
 
-   .. attribute:: showObj_val(=true)
+   .. attribute:: show_obj_val(=true)
    Shows the current value of the objective function.
 
-   .. attribute:: showLR(=false)
+   .. attribute:: show_lr(=false)
    Shows the current value of the learning rate.
 
-   .. attribute:: showMom(=false)
+   .. attribute:: show_mom(=false)
    Shows the current momentum.
 
-   The training summary at iteration 0 shows the results before training starts.
+   Here are a few examples of usage:
+
+   .. code-block:: julia
+
+      #same as original functionality, shows iteration and obj_val by defualt
+      TrainingSummary()
+   
+      #will only show objective function value
+      TrainingSummary(show_iter=false)
+
+      #shows iteration, obj_val, learning_rate, and momentum
+      TrainingSummary(show_lr=true,show_mom=true)
+
+   Note that the training summary at iteration 0 shows the results before training starts.
+   Also, any values that are shown with this method will also be added to the lounge 
+   using the `update_statistics()` function.
 
 .. class:: Snapshot
 

--- a/docs/user-guide/solver.rst
+++ b/docs/user-guide/solver.rst
@@ -225,9 +225,21 @@ Built-in Coffee Breaks
 .. class:: TrainingSummary
 
    This is a coffee break in which the solver talks about the training summary.
-   Currently, only the training objective function value at the current
-   iteration is reported. Reporting for other solver states like the current
-   learning rate and momentum could be easily added.
+   The training objective function value at the current
+   iteration is reported by default. You can also call the function with the following
+   named parameters in order to customize the output:
+
+   .. attribute:: showIter(=true)
+   Shows the current iteration number.
+
+   .. attribute:: showObj_val(=true)
+   Shows the current value of the objective function.
+
+   .. attribute:: showLR(=false)
+   Shows the current value of the learning rate.
+
+   .. attribute:: showMom(=false)
+   Shows the current momentum.
 
    The training summary at iteration 0 shows the results before training starts.
 

--- a/src/coffee/training-summary.jl
+++ b/src/coffee/training-summary.jl
@@ -7,14 +7,11 @@ type TrainingSummary <: Coffee
   dispMom:: Bool
   
   #Default Constructor
-  #Put the "string" parameter to make the rest be optional
-  function TrainingSummary(string="dontuseme";showIter=true,showObj_val=true,showLR=false,showMom=false)
+  function TrainingSummary(;showIter=true,showObj_val=true,showLR=false,showMom=false)
     newTrainingSummary = new(showIter,showObj_val,showLR,showMom)
 
     return newTrainingSummary
   end
-
-  TrainingSummary() = new(true,true,false,false)
 
 end
 

--- a/src/coffee/training-summary.jl
+++ b/src/coffee/training-summary.jl
@@ -5,7 +5,7 @@ end
 
 function enjoy(lounge::CoffeeLounge, ::TrainingSummary, ::Net, state::SolverState)
   # we do not report objective value at iteration 0 because it has not been computed yet
-  summary = @sprintf("%06d :: TRAIN obj-val = %.8f", state.iter, state.obj_val)
+  summary = @sprintf("%06d :: TRAIN obj-val = %.8f :: LR = %8f :: Mom = %8f", state.iter, state.obj_val, state.learning_rate, state.momentum)
   @info(summary)
 
   update_statistics(lounge, "obj-val", state.obj_val)

--- a/src/coffee/training-summary.jl
+++ b/src/coffee/training-summary.jl
@@ -1,14 +1,14 @@
 export TrainingSummary
 
 type TrainingSummary <: Coffee
-  dispIter :: Bool
-  dispObj_val :: Bool
-  dispLR :: Bool
-  dispMom:: Bool
+  show_iter :: Bool
+  show_obj_val :: Bool
+  show_lr :: Bool
+  show_mom:: Bool
   
   #Default Constructor
-  function TrainingSummary(;showIter=true,showObj_val=true,showLR=false,showMom=false)
-    newTrainingSummary = new(showIter,showObj_val,showLR,showMom)
+  function TrainingSummary(;show_iter=true,show_obj_val=true,show_lr=false,show_mom=false)
+    newTrainingSummary = new(show_iter,show_obj_val,show_lr,show_mom)
 
     return newTrainingSummary
   end
@@ -17,33 +17,34 @@ end
 
 function enjoy(lounge::CoffeeLounge, coffee::TrainingSummary, ::Net, state::SolverState)
   # we do not report objective value at iteration 0 because it has not been computed yet
-  if coffee.dispIter
-    txtIter = @sprintf("ITER = %06d",state.iter)
+  if coffee.show_iter
+    txt_iter = @sprintf("ITER = %06d",state.iter)
   else
-    txtIter = ""
+    txt_iter = ""
   end
 
-  if coffee.dispObj_val
-    txtObj_val = @sprintf(":: TRAIN obj-val = %.8f",state.obj_val)
+  if coffee.show_obj_val
+    txt_obj_val = @sprintf(":: TRAIN obj-val = %.8f",state.obj_val)
+    update_statistics(lounge, "obj-val", state.obj_val)
   else
-    txtObj_val = ""
+    txt_obj_val = ""
   end
 
-  if coffee.dispLR
-    txtLR = @sprintf(":: LR = %.8f",state.learning_rate)
+  if coffee.show_lr
+    txt_lr = @sprintf(":: LR = %.8f",state.learning_rate)
+    update_statistics(lounge, "learning-rate", state.learning_rate)
   else
-    txtLR = ""
+    txt_lr = ""
   end
 
-  if coffee.dispMom
-    txtMom = @sprintf(":: MOM = %.8f",state.momentum)
+  if coffee.show_mom
+    txt_mom = @sprintf(":: MOM = %.8f",state.momentum)
+    update_statistics(lounge, "momentum", state.momentum)
   else
-    txtMom = ""
+    txt_mom = ""
   end
 
-  summary = string(txtIter,txtObj_val,txtLR,txtMom)
+  summary = string(txt_iter,txt_obj_val,txt_lr,txt_mom)
   
   @info(summary)
-
-  update_statistics(lounge, "obj-val", state.obj_val)
 end

--- a/src/coffee/training-summary.jl
+++ b/src/coffee/training-summary.jl
@@ -1,11 +1,51 @@
 export TrainingSummary
 
 type TrainingSummary <: Coffee
+  dispIter :: Bool
+  dispObj_val :: Bool
+  dispLR :: Bool
+  dispMom:: Bool
+  
+  #Default Constructor
+  #Put the "string" parameter to make the rest be optional
+  function TrainingSummary(string="dontuseme";showIter=true,showObj_val=true,showLR=false,showMom=false)
+    newTrainingSummary = new(showIter,showObj_val,showLR,showMom)
+
+    return newTrainingSummary
+  end
+
+  TrainingSummary() = new(true,true,false,false)
+
 end
 
-function enjoy(lounge::CoffeeLounge, ::TrainingSummary, ::Net, state::SolverState)
+function enjoy(lounge::CoffeeLounge, coffee::TrainingSummary, ::Net, state::SolverState)
   # we do not report objective value at iteration 0 because it has not been computed yet
-  summary = @sprintf("%06d :: TRAIN obj-val = %.8f :: LR = %8f :: Mom = %8f", state.iter, state.obj_val, state.learning_rate, state.momentum)
+  if coffee.dispIter
+    txtIter = @sprintf("ITER = %06d",state.iter)
+  else
+    txtIter = ""
+  end
+
+  if coffee.dispObj_val
+    txtObj_val = @sprintf(":: TRAIN obj-val = %.8f",state.obj_val)
+  else
+    txtObj_val = ""
+  end
+
+  if coffee.dispLR
+    txtLR = @sprintf(":: LR = %.8f",state.learning_rate)
+  else
+    txtLR = ""
+  end
+
+  if coffee.dispMom
+    txtMom = @sprintf(":: MOM = %.8f",state.momentum)
+  else
+    txtMom = ""
+  end
+
+  summary = string(txtIter,txtObj_val,txtLR,txtMom)
+  
   @info(summary)
 
   update_statistics(lounge, "obj-val", state.obj_val)


### PR DESCRIPTION
I have made the following simple change to TrainingSummary() to allow for named parameters that will include/not-include: iteration, obj_val, learning_rate, and momentum.

I included a dummy string variable that allow the booleans to be named. I am not really sure of a better way to do this. But I feel like it is ugly.

If the user uses no parameters the behavior defualts to the current behavior.