### PR TITLE
HDF5InputDataLayer fails with shuffle=true if data is not 4 dimensional

### DIFF
--- a/src/layers/hdf5-data.jl
+++ b/src/layers/hdf5-data.jl
@@ -51,7 +51,7 @@ type HDF5DataLayerState <: LayerState
       # we only use mmap when random shuffle is required, as mmap is slower
       # than sequential batch read. see hdf5-read benchmark.
       state.dsets = map(readmmap, state.dsets)
-      state.shuffle_idx = randperm(size(state.dsets[1],4))
+      state.shuffle_idx = randperm(size(state.dsets[1])[end])
     else
       state.shuffle_idx = Int[]
     end
@@ -144,4 +144,3 @@ end
 
 function backward(backend::Backend, state::HDF5DataLayerState, inputs::Vector{Blob}, diffs::Vector{Blob})
 end
-


### PR DESCRIPTION
HDF5DataLayer assumes that input data is 4D in one place. Noe that my fix makes line 54 be the same as line 102