### PR TITLE
Type error in solvers.jl

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -92,7 +92,7 @@ type Staged <: LearningRatePolicy
   curr_stage :: Int
 
   Staged(stages...) = begin
-    accum_stages = Array(Tuple{Int, LRPolicy.Fixed}, length(stages))
+    accum_stages = Array(Tuple{Int, LearningRatePolicy}, length(stages))
     accum_iter = 0
     for i = 1:length(stages)
       (n, lrp) = stages[i]
@@ -180,7 +180,7 @@ type Staged <: MomentumPolicy
   curr_stage :: Int
 
   Staged(stages...) = begin
-    accum_stages = Array(Tuple{Int, MomPolicy.Fixed}, length(stages))
+    accum_stages = Array(Tuple{Int, MomentumPolicy}, length(stages))
     accum_iter = 0
     for i = 1:length(stages)
       (n, mmp) = stages[i]

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -92,7 +92,7 @@ type Staged <: LearningRatePolicy
   curr_stage :: Int
 
   Staged(stages...) = begin
-    accum_stages = Array((Int, LearningRatePolicy), length(stages))
+    accum_stages = Array(Tuple{Int, LRPolicy.Fixed}, length(stages))
     accum_iter = 0
     for i = 1:length(stages)
       (n, lrp) = stages[i]
@@ -180,7 +180,7 @@ type Staged <: MomentumPolicy
   curr_stage :: Int
 
   Staged(stages...) = begin
-    accum_stages = Array((Int, MomentumPolicy), length(stages))
+    accum_stages = Array(Tuple{Int, MomPolicy.Fixed}, length(stages))
     accum_iter = 0
     for i = 1:length(stages)
       (n, mmp) = stages[i]


### PR DESCRIPTION
I tried `examples/test.jl` and got under error.

https://gist.github.com/iizukak/b657e0a5fcc98a2ce346

Condition
* Julia
  * `Version 0.4.0-dev+6873 (2015-08-21 14:35 UTC)`
  * `Commit 4acdff2* (0 days old master)`
  * `x86_64-apple-darwin14.5.0`
* Mocha: 
  * `63e8a93` (latest master)

I noticed `test.jl` fail at [line 50 in test.jl](https://github.com/pluskid/Mocha.jl/blob/master/examples/test.jl#L40) and [line 95 in solvers.jl](https://github.com/pluskid/Mocha.jl/blob/master/src/solvers.jl#L95)

```
julia> lr_policy = LRPolicy.Staged(
         (6000, LRPolicy.Fixed(0.001)),
         (4000, LRPolicy.Fixed(0.0001)),
       )

ERROR: MethodError: `convert` has no method matching convert(::Type{Array{T,N}}, ::Tuple{DataType,DataType}, ::Int64)
This may have arisen from a call to the constructor Array{T,N}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  Array{T}(::Type{T}, ::Integer)
  Array{T}(::Type{T}, ::Integer, ::Integer)
  Array{T}(::Type{T}, ::Integer, ::Integer, ::Integer)
  ...
 in call at /Users/kentaro/.julia/v0.4/Mocha/src/solvers.jl:95
```

after this PR, `test.jl` run without error.

I noticed same problem at [line 183](https://github.com/pluskid/Mocha.jl/blob/master/src/solvers.jl#L183). [This code](https://gist.github.com/pluskid/7c9998b0e9047488d20a#file-decay-on-validation-example-jl-L3)  cause under error

```
julia> MomPolicy.Staged((30000, MomPolicy.Fixed(0.0)),(50000,MomPolicy.Fixed(0.1)),(90000,MomPolicy.Fixed(0.3)),(200000,MomPolicy.Fixed(0.7)),(10000,MomPolicy.Fixed(0.9)))
ERROR: MethodError: `convert` has no method matching convert(::Type{Array{T,N}}, ::Tuple{DataType,DataType}, ::Int64)
This may have arisen from a call to the constructor Array{T,N}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  Array{T}(::Type{T}, ::Integer)
  Array{T}(::Type{T}, ::Integer, ::Integer)
  Array{T}(::Type{T}, ::Integer, ::Integer, ::Integer)
  ...
 in call at /Users/kentaro/.julia/v0.4/Mocha/src/solvers.jl:183
```

I think 2 problems are fixed in this PR.