### PR TITLE
Parentheses correspond problem in solvers.jl

### DIFF
--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -92,7 +92,7 @@ type Staged <: LearningRatePolicy
   curr_stage :: Int
 
   Staged(stages...) = begin
-    accum_stages = Array(@compat(Tuple{Int, LearningRatePolicy}, length(stages)))
+    accum_stages = Array(@compat(Tuple{Int, LearningRatePolicy}), length(stages))
     accum_iter = 0
     for i = 1:length(stages)
       (n, lrp) = stages[i]
@@ -180,7 +180,7 @@ type Staged <: MomentumPolicy
   curr_stage :: Int
 
   Staged(stages...) = begin
-    accum_stages = Array(@compat(Tuple{Int, MomentumPolicy}, length(stages)))
+    accum_stages = Array(@compat(Tuple{Int, MomentumPolicy}), length(stages))
     accum_iter = 0
     for i = 1:length(stages)
       (n, mmp) = stages[i]


### PR DESCRIPTION
I think latest commit [c712947e](https://github.com/pluskid/Mocha.jl/commit/c712947e476c7aa6e8e9bd6ac9d6f766bbd8ea79) contains parentheses correspond problem.

```
julia> using Mocha
Configuring Mocha...
 * CUDA       disabled by default
 * Native Ext disabled by default
Mocha configured, continue loading module...
INFO: Recompiling stale cache file /Users/kentaro/.julia/lib/v0.4/HDF5.ji for module HDF5.
INFO: Recompiling stale cache file /Users/kentaro/.julia/lib/v0.4/JLD.ji for module JLD.
ERROR: LoadError: LoadError: wrong number of arguments
 in include at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in include_from_node1 at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in include at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in include_from_node1 at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
 in require at /usr/local/Cellar/julia/HEAD/lib/julia/sys.dylib
while loading /Users/kentaro/.julia/v0.4/Mocha/src/solvers.jl, in expression starting on line 90
while loading /Users/kentaro/.julia/v0.4/Mocha/src/Mocha.jl, in expression starting on line 75
```