### PR TITLE
Version compare problem with v0.4-dev

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -10,7 +10,7 @@ else
   end
 end
 
-if VERSION < v"0.4.0"
+if VERSION < v"0.4-"
   Libdl = Base
 else
   Libdl = Base.Libdl


### PR DESCRIPTION
I'm using Julia version `v"0.4.0-dev+6916"` and found passing [this line](https://github.com/pluskid/Mocha.jl/blob/master/src/compatibility.jl#L14).
I think development version of v0.4 should pass [else line](https://github.com/pluskid/Mocha.jl/blob/master/src/compatibility.jl#L16).

[Version Number String](http://julia.readthedocs.org/en/latest/manual/strings/#version-number-literals) behaves as below.

```
julia> VERSION
v"0.4.0-dev+6916"

julia> VERSION < v"0.4.0"
true

julia> VERSION >= v"0.4.0"
false

julia> VERSION < v"0.4-"
false

julia> VERSION >= v"0.4-"
true

julia> v"0.3.11" < v"0.4-"
true
```

This PR reduce [deprecated warning](https://gist.github.com/iizukak/f2b73ceb79239d3a2683) of MNIST example.