### PR TITLE
Fix for CUDA libraries on windows

### DIFF
--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -3,15 +3,14 @@ export CUDA
 module CUDA
 export CuPtr
 
-@osx_only begin
-  const libcuda = "libcuda"
+@windows? (
+begin
+    const libcuda = Libdl.find_library(["nvcuda.dll"], [""])
 end
-@linux_only begin
-  const libcuda = "libcuda"
-end
-@windows_only begin
-  const libcuda = "nvcuda.dll"
-end
+: # linux or mac
+begin
+    const libcuda = Libdl.find_library(["libcuda"], [""])
+end)
 
 using Compat
 const driver_error_descriptions = @compat(Dict(


### PR DESCRIPTION
The library was not working with the GPU backend on Windows due to the differences in library names between OSes. Changed to use Libdl.find_library() to find library locations. Tests passing on windows for both CPU and GPU backends.