### PR TITLE
Some updates for Julia v0.4.0-rc1

### DIFF
--- a/src/blob.jl
+++ b/src/blob.jl
@@ -165,5 +165,5 @@ end
 function randn!(a::Array{Float32})
     # TODO This is hideously inefficient - check status of Julia issue
     # https://github.com/JuliaLang/julia/issues/9836
-    a[:] = float32(randn(size(a)))
+    a[:] = map(Float32, randn(size(a)))
 end

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -165,5 +165,5 @@ end
 function randn!(a::Array{Float32})
     # TODO This is hideously inefficient - check status of Julia issue
     # https://github.com/JuliaLang/julia/issues/9836
-    a[:] = map(Float32, randn(size(a)))
+    a[:] = float32(randn(size(a)))
 end

--- a/src/cuda/cublas.jl
+++ b/src/cuda/cublas.jl
@@ -95,7 +95,7 @@ end
 function set_vector{T}(src::Array{T}, incx::Int, dest::CuPtr, incy::Int)
   elem_size = sizeof(T)
   n = length(src)
-  src_buf = convert(Ptr{Void}, pointer(src))
+  src_buf = Compat.unsafe_convert(Ptr{Void}, pointer(src))
   set_vector(n, elem_size, src_buf, incx, dest, incy)
 end
 set_vector{T}(src::Array{T}, dest::CuPtr) = set_vector(src, 1, dest, 1)
@@ -110,7 +110,7 @@ end
 function get_vector{T}(src::CuPtr, incx::Int, dest::Array{T}, incy::Int)
   elem_size = sizeof(T)
   n = length(dest)
-  dest_buf = convert(Ptr{Void}, pointer(dest))
+  dest_buf = Compat.unsafe_convert(Ptr{Void}, pointer(dest))
   get_vector(n, elem_size, src, incx, dest_buf, incy)
 end
 get_vector{T}(src::CuPtr, dest::Array{T}) = get_vector(src, 1, dest, 1)

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -182,7 +182,7 @@ immutable CuStream
 end
 
 function null_stream()
-  CuStream(convert(Ptr{Void}, 0), true, 0)
+  CuStream(Compat.unsafe_convert(Ptr{Void}, 0), true, 0)
 end
 
 function destroy(s::CuStream)

--- a/src/cuda/layers/accuracy.jl
+++ b/src/cuda/layers/accuracy.jl
@@ -15,8 +15,8 @@ function forward(backend::GPUBackend, state::AccuracyLayerState, inputs::Vector{
   spatial_dim, pred_dim, num = split_dims(pred, state.op_dim)
   data_type = eltype(pred)
 
-  x_block = round(Int64, ceil(float64(num)/CUDA.THREADS_PER_BLOCK_X));
-  y_block = round(Int64, ceil(float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
+  x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
+  y_block = round(Int64, ceil(Float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
 
   if data_type == Float32
     kernel = backend.mocha.accuracy_forward_float

--- a/src/cuda/layers/accuracy.jl
+++ b/src/cuda/layers/accuracy.jl
@@ -15,8 +15,8 @@ function forward(backend::GPUBackend, state::AccuracyLayerState, inputs::Vector{
   spatial_dim, pred_dim, num = split_dims(pred, state.op_dim)
   data_type = eltype(pred)
 
-  x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
-  y_block = round(Int64, ceil(Float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
+  x_block = round(Int64, ceil(convert(Float64, num)/CUDA.THREADS_PER_BLOCK_X));
+  y_block = round(Int64, ceil(convert(Float64, spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
 
   if data_type == Float32
     kernel = backend.mocha.accuracy_forward_float

--- a/src/cuda/layers/argmax.jl
+++ b/src/cuda/layers/argmax.jl
@@ -6,8 +6,8 @@ function forward(backend::GPUBackend, state::ArgmaxLayerState, inputs::Vector{Bl
     spatial_dim, channels, num = split_dims(input, state.dims[i])
     data_type = eltype(input)
 
-    x_block = round(Int64, ceil(float64(num)/CUDA.THREADS_PER_BLOCK_X));
-    y_block = round(Int64, ceil(float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
+    x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
+    y_block = round(Int64, ceil(Float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
 
     if data_type == Float32
       kernel = backend.mocha.argmax_forward_float

--- a/src/cuda/layers/argmax.jl
+++ b/src/cuda/layers/argmax.jl
@@ -6,8 +6,8 @@ function forward(backend::GPUBackend, state::ArgmaxLayerState, inputs::Vector{Bl
     spatial_dim, channels, num = split_dims(input, state.dims[i])
     data_type = eltype(input)
 
-    x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
-    y_block = round(Int64, ceil(Float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
+    x_block = round(Int64, ceil(convert(Float64, num)/CUDA.THREADS_PER_BLOCK_X));
+    y_block = round(Int64, ceil(convert(Float64, spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
 
     if data_type == Float32
       kernel = backend.mocha.argmax_forward_float

--- a/src/cuda/layers/binary-cross-entropy-loss.jl
+++ b/src/cuda/layers/binary-cross-entropy-loss.jl
@@ -6,7 +6,7 @@ function forward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, i
   num = get_num(pred)
   dim = length(pred)
 
-  x_block = int(ceil(float64(dim)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = int(ceil(Float64(dim)/CUDA.THREADS_PER_BLOCK_X))
 
   loss_blob = make_zero_blob(backend, Float32, 1, 1, 1, 1)
 
@@ -39,7 +39,7 @@ function backward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, 
   num = get_num(pred)
   dim = length(pred)
 
-  x_block = int(ceil(float64(dim)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = int(ceil(Float64(dim)/CUDA.THREADS_PER_BLOCK_X))
 
   if data_type == Float32
     kernel = backend.mocha.binary_cross_entropy_loss_backward_float

--- a/src/cuda/layers/binary-cross-entropy-loss.jl
+++ b/src/cuda/layers/binary-cross-entropy-loss.jl
@@ -6,7 +6,7 @@ function forward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, i
   num = get_num(pred)
   dim = length(pred)
 
-  x_block = int(ceil(Float64(dim)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = int(ceil(convert(Float64, dim)/CUDA.THREADS_PER_BLOCK_X))
 
   loss_blob = make_zero_blob(backend, Float32, 1, 1, 1, 1)
 
@@ -39,7 +39,7 @@ function backward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, 
   num = get_num(pred)
   dim = length(pred)
 
-  x_block = int(ceil(Float64(dim)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = int(ceil(convert(Float64, dim)/CUDA.THREADS_PER_BLOCK_X))
 
   if data_type == Float32
     kernel = backend.mocha.binary_cross_entropy_loss_backward_float

--- a/src/cuda/layers/binary-cross-entropy-loss.jl
+++ b/src/cuda/layers/binary-cross-entropy-loss.jl
@@ -49,7 +49,7 @@ function backward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, 
     error("Unsupported data type $data_type")
   end
 
-  null_ptr = convert(Ptr{data_type}, 0)
+  null_ptr = Compat.unsafe_convert(Ptr{data_type}, 0)
   grad_pred =  isa(diffs[1], CuTensorBlob) ? diffs[1].ptr.p : null_ptr
   grad_label = isa(diffs[2], CuTensorBlob) ? diffs[2].ptr.p : null_ptr
 

--- a/src/cuda/layers/channel-pooling.jl
+++ b/src/cuda/layers/channel-pooling.jl
@@ -147,9 +147,9 @@ end
 
 
 function cuda_geometry_max_chann_pool(sp_dim::Int, num::Int)
-  x_block = round(Int64, ceil(float64(num)/CUDA.THREADS_PER_BLOCK_X));
+  x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
   y_block = 1;
-  z_block = round(Int64, ceil(float64(sp_dim)/CUDA.THREADS_PER_BLOCK_Z));
+  z_block = round(Int64, ceil(Float64(sp_dim)/CUDA.THREADS_PER_BLOCK_Z));
   return ((x_block,y_block,z_block),
           (CUDA.THREADS_PER_BLOCK_X,1,CUDA.THREADS_PER_BLOCK_Z))
 

--- a/src/cuda/layers/channel-pooling.jl
+++ b/src/cuda/layers/channel-pooling.jl
@@ -147,9 +147,9 @@ end
 
 
 function cuda_geometry_max_chann_pool(sp_dim::Int, num::Int)
-  x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
+  x_block = round(Int64, ceil(convert(Float64, num)/CUDA.THREADS_PER_BLOCK_X));
   y_block = 1;
-  z_block = round(Int64, ceil(Float64(sp_dim)/CUDA.THREADS_PER_BLOCK_Z));
+  z_block = round(Int64, ceil(convert(Float64, sp_dim)/CUDA.THREADS_PER_BLOCK_Z));
   return ((x_block,y_block,z_block),
           (CUDA.THREADS_PER_BLOCK_X,1,CUDA.THREADS_PER_BLOCK_Z))
 

--- a/src/cuda/layers/channel-pooling.jl
+++ b/src/cuda/layers/channel-pooling.jl
@@ -1,3 +1,5 @@
+using Compat
+
 function setup_etc(backend::GPUBackend, layer::ChannelPoolingLayer, inputs, blobs)
   if isa(layer.pooling, Pooling.Max)
     masks = Array(CuPtr, length(inputs))
@@ -83,9 +85,9 @@ function cuda_mean_channel_pooling_forward{T}(backend::GPUBackend, input::CuTens
   output_fea_dim = spatial_dim * pooled_chann
 
   for n = 1:num
-    input_ptr = convert(Ptr{T}, input.ptr.p) + fea_dim*(n-1)
-    output_ptr = convert(Ptr{T}, output.ptr.p) + output_fea_dim*(n-1)
-    integral_ptr = convert(Ptr{T}, integral.p)
+    input_ptr = Compat.unsafe_convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
+    output_ptr = Compat.unsafe_convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
+    integral_ptr = Compat.unsafe_convert(Ptr{T}, integral.p)
 
     # compute integral image
     CuBLAS.copy(backend.cublas_ctx, T, spatial_dim_T, input_ptr, 1, integral_ptr, 1)
@@ -128,8 +130,8 @@ function cuda_mean_channel_pooling_backward{T}(backend::GPUBackend, input::CuTen
   output_fea_dim = spatial_dim * pooled_chann
 
   for n = 1:num
-    input_ptr = convert(Ptr{T}, input.ptr.p) + fea_dim*(n-1)
-    output_ptr = convert(Ptr{T}, output.ptr.p) + output_fea_dim*(n-1)
+    input_ptr = Compat.unsafe_convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
+    output_ptr = Compat.unsafe_convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
 
     for pc = 1:pooled_chann
       cstart = (pc-1)*layer.stride - layer.pad[1] + 1

--- a/src/cuda/layers/dropout.jl
+++ b/src/cuda/layers/dropout.jl
@@ -10,7 +10,7 @@ function setup_etc(backend::GPUBackend, layer::DropoutLayer, inputs::Vector{Blob
 
   len = length(inputs[1])
   cuda_rand_states = CUDA.cualloc(Uint8, rnd_state_size*len)
-  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
   CUDA.launch(kernel, x_block, CUDA.THREADS_PER_BLOCK_X, (cuda_rand_states, len))
 
   return cuda_rand_states
@@ -22,7 +22,7 @@ end
 
 function forward(backend::GPUBackend, state::DropoutLayerState, inputs::Vector{Blob})
   len = length(inputs[1])
-  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
   data_type = eltype(inputs[1])
   if data_type == Float32
     kernel = backend.mocha.dropout_forward_float
@@ -38,7 +38,7 @@ end
 function backward(backend::GPUBackend, state::DropoutLayerState, inputs::Vector{Blob}, diffs::Vector{Blob})
   if !isa(diffs[1], NullBlob)
     len = length(inputs[1])
-    x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+    x_block = round(Int64, ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
     data_type = eltype(inputs[1])
     if data_type == Float32
       kernel = backend.mocha.dropout_backward_float

--- a/src/cuda/layers/dropout.jl
+++ b/src/cuda/layers/dropout.jl
@@ -10,7 +10,7 @@ function setup_etc(backend::GPUBackend, layer::DropoutLayer, inputs::Vector{Blob
 
   len = length(inputs[1])
   cuda_rand_states = CUDA.cualloc(Uint8, rnd_state_size*len)
-  x_block = round(Int64, ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
   CUDA.launch(kernel, x_block, CUDA.THREADS_PER_BLOCK_X, (cuda_rand_states, len))
 
   return cuda_rand_states
@@ -22,7 +22,7 @@ end
 
 function forward(backend::GPUBackend, state::DropoutLayerState, inputs::Vector{Blob})
   len = length(inputs[1])
-  x_block = round(Int64, ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
   data_type = eltype(inputs[1])
   if data_type == Float32
     kernel = backend.mocha.dropout_forward_float
@@ -38,7 +38,7 @@ end
 function backward(backend::GPUBackend, state::DropoutLayerState, inputs::Vector{Blob}, diffs::Vector{Blob})
   if !isa(diffs[1], NullBlob)
     len = length(inputs[1])
-    x_block = round(Int64, ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+    x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
     data_type = eltype(inputs[1])
     if data_type == Float32
       kernel = backend.mocha.dropout_backward_float

--- a/src/cuda/layers/hdf5-data.jl
+++ b/src/cuda/layers/hdf5-data.jl
@@ -1,6 +1,6 @@
 function set_blob_data{T}(data::Array{T}, blob::CuTensorBlob{T}, blob_idx::Int)
   n_fea = get_fea_size(blob)
   ptr = Compat.unsafe_convert(Ptr{Void}, blob.ptr.p) + sizeof(T) * n_fea * (blob_idx-1) # note 0-based indexing in CUDA Vector
-  CuBLAS.set_vector(length(data), sizeof(T), convert(Ptr{Void},pointer(data)), 1, ptr, 1)
+  CuBLAS.set_vector(length(data), sizeof(T), Compat.unsafe_convert(Ptr{Void},pointer(data)), 1, ptr, 1)
 end
 

--- a/src/cuda/layers/index2onehot.jl
+++ b/src/cuda/layers/index2onehot.jl
@@ -7,8 +7,8 @@ function forward(backend::GPUBackend, state::Index2OnehotLayerState, inputs::Vec
     spatial_dim, channels, num = split_dims(output, state.dims[i])
     data_type = eltype(input)
 
-    x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
-    y_block = round(Int64, ceil(Float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
+    x_block = round(Int64, ceil(convert(Float64, num)/CUDA.THREADS_PER_BLOCK_X));
+    y_block = round(Int64, ceil(convert(Float64, spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
 
     if data_type == Float32
       kernel = backend.mocha.index2onehot_forward_float

--- a/src/cuda/layers/index2onehot.jl
+++ b/src/cuda/layers/index2onehot.jl
@@ -7,8 +7,8 @@ function forward(backend::GPUBackend, state::Index2OnehotLayerState, inputs::Vec
     spatial_dim, channels, num = split_dims(output, state.dims[i])
     data_type = eltype(input)
 
-    x_block = round(Int64, ceil(float64(num)/CUDA.THREADS_PER_BLOCK_X));
-    y_block = round(Int64, ceil(float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
+    x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X));
+    y_block = round(Int64, ceil(Float64(spatial_dim)/CUDA.THREADS_PER_BLOCK_Y));
 
     if data_type == Float32
       kernel = backend.mocha.index2onehot_forward_float

--- a/src/cuda/layers/multinomial-logistic-loss.jl
+++ b/src/cuda/layers/multinomial-logistic-loss.jl
@@ -20,7 +20,7 @@ function forward(backend::GPUBackend, state::MultinomialLogisticLossLayerState, 
   end
 
   if isa(state.weights_blob, NullBlob)
-    weights = convert(Ptr{data_type}, 0)
+    weights = Compat.unsafe_convert(Ptr{data_type}, 0)
   else
     weights = state.weights_blob.ptr.p
   end

--- a/src/cuda/layers/random-normal.jl
+++ b/src/cuda/layers/random-normal.jl
@@ -14,7 +14,7 @@ function setup_etc(backend::GPUBackend, layer::RandomNormalLayer)
   for i = 1:length(layer.tops)
       len = outlen*layer.batch_sizes[i]
       cuda_rand_states = CUDA.cualloc(Uint8, rnd_state_size*len)
-      x_block = int(ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+      x_block = int(ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
       seed = rand(Uint64)
       println("launching stdnormal init on bloc $i with len $len")
       CUDA.launch(kernel, x_block, CUDA.THREADS_PER_BLOCK_X, (cuda_rand_states, seed))
@@ -32,7 +32,7 @@ end
 function forward(backend::GPUBackend, state::RandomNormalLayerState, inputs::Vector{Blob})
     for i = 1:length(state.blobs)
         len = length(state.blobs[i])
-        x_block = int(ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+        x_block = int(ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
         data_type = state.layer.eltype
         if data_type == Float32
             kernel = backend.mocha.stdnormal_forward_float

--- a/src/cuda/layers/random-normal.jl
+++ b/src/cuda/layers/random-normal.jl
@@ -14,7 +14,7 @@ function setup_etc(backend::GPUBackend, layer::RandomNormalLayer)
   for i = 1:length(layer.tops)
       len = outlen*layer.batch_sizes[i]
       cuda_rand_states = CUDA.cualloc(Uint8, rnd_state_size*len)
-      x_block = int(ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+      x_block = int(ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
       seed = rand(Uint64)
       println("launching stdnormal init on bloc $i with len $len")
       CUDA.launch(kernel, x_block, CUDA.THREADS_PER_BLOCK_X, (cuda_rand_states, seed))
@@ -32,7 +32,7 @@ end
 function forward(backend::GPUBackend, state::RandomNormalLayerState, inputs::Vector{Blob})
     for i = 1:length(state.blobs)
         len = length(state.blobs[i])
-        x_block = int(ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+        x_block = int(ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
         data_type = state.layer.eltype
         if data_type == Float32
             kernel = backend.mocha.stdnormal_forward_float

--- a/src/cuda/layers/softmax-loss.jl
+++ b/src/cuda/layers/softmax-loss.jl
@@ -7,7 +7,7 @@ function backward(backend::GPUBackend, state::SoftmaxLossLayerState, inputs::Vec
     spatial_dim, channels, num = split_dims(diff, state.logistic.op_dim)
     prob_dim = channels
 
-    x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X))
+    x_block = round(Int64, ceil(convert(Float64, num)/CUDA.THREADS_PER_BLOCK_X))
     y_block = spatial_dim
 
     if isa(state.logistic.weights_blob, NullBlob)

--- a/src/cuda/layers/softmax-loss.jl
+++ b/src/cuda/layers/softmax-loss.jl
@@ -7,7 +7,7 @@ function backward(backend::GPUBackend, state::SoftmaxLossLayerState, inputs::Vec
     spatial_dim, channels, num = split_dims(diff, state.logistic.op_dim)
     prob_dim = channels
 
-    x_block = round(Int64, ceil(float64(num)/CUDA.THREADS_PER_BLOCK_X))
+    x_block = round(Int64, ceil(Float64(num)/CUDA.THREADS_PER_BLOCK_X))
     y_block = spatial_dim
 
     if isa(state.logistic.weights_blob, NullBlob)

--- a/src/cuda/layers/softmax-loss.jl
+++ b/src/cuda/layers/softmax-loss.jl
@@ -11,7 +11,7 @@ function backward(backend::GPUBackend, state::SoftmaxLossLayerState, inputs::Vec
     y_block = spatial_dim
 
     if isa(state.logistic.weights_blob, NullBlob)
-      weights = convert(Ptr{data_type}, 0)
+      weights = Compat.unsafe_convert(Ptr{data_type}, 0)
     else
       weights = state.logistic.weights_blob.ptr.p
     end

--- a/src/cuda/neurons.jl
+++ b/src/cuda/neurons.jl
@@ -1,7 +1,7 @@
 function cuda_geometry(:: ActivationFunction, output :: Blob)
   len = length(output)
 
-  x_block = round(Int64, ceil(float64(len)/1024));
+  x_block = round(Int64, ceil(Float64(len)/1024));
   return ((x_block,1024), (len,))
 end
 

--- a/src/cuda/neurons.jl
+++ b/src/cuda/neurons.jl
@@ -1,7 +1,7 @@
 function cuda_geometry(:: ActivationFunction, output :: Blob)
   len = length(output)
 
-  x_block = round(Int64, ceil(Float64(len)/1024));
+  x_block = round(Int64, ceil(convert(Float64, len)/1024));
   return ((x_block,1024), (len,))
 end
 

--- a/src/cuda/regularizers.jl
+++ b/src/cuda/regularizers.jl
@@ -17,7 +17,7 @@ function forward(backend::GPUBackend, regu :: L1Regu, global_regu::FloatingPoint
   loss_blob = make_zero_blob(backend, Float32, 1, 1, 1, 1)
   len = length(param)
   coef = convert(eltype(param), regu.coefficient * global_regu)
-  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
   if eltype(param) == Float32
     kernel = backend.mocha.l1_forward_float
   else
@@ -30,7 +30,7 @@ function forward(backend::GPUBackend, regu :: L1Regu, global_regu::FloatingPoint
 end
 function backward(backend::GPUBackend, regu :: L1Regu, global_regu::FloatingPoint, param :: Blob, gradient :: Blob)
   len = length(param)
-  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(convert(Float64, len)/CUDA.THREADS_PER_BLOCK_X))
   coef = convert(eltype(param), regu.coefficient * global_regu)
   if eltype(param) == Float32
     kernel = backend.mocha.l1_backward_float

--- a/src/cuda/regularizers.jl
+++ b/src/cuda/regularizers.jl
@@ -17,7 +17,7 @@ function forward(backend::GPUBackend, regu :: L1Regu, global_regu::FloatingPoint
   loss_blob = make_zero_blob(backend, Float32, 1, 1, 1, 1)
   len = length(param)
   coef = convert(eltype(param), regu.coefficient * global_regu)
-  x_block = round(Int64, ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
   if eltype(param) == Float32
     kernel = backend.mocha.l1_forward_float
   else
@@ -30,7 +30,7 @@ function forward(backend::GPUBackend, regu :: L1Regu, global_regu::FloatingPoint
 end
 function backward(backend::GPUBackend, regu :: L1Regu, global_regu::FloatingPoint, param :: Blob, gradient :: Blob)
   len = length(param)
-  x_block = round(Int64, ceil(float64(len)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = round(Int64, ceil(Float64(len)/CUDA.THREADS_PER_BLOCK_X))
   coef = convert(eltype(param), regu.coefficient * global_regu)
   if eltype(param) == Float32
     kernel = backend.mocha.l1_backward_float

--- a/src/cuda/utils/math.jl
+++ b/src/cuda/utils/math.jl
@@ -2,6 +2,8 @@ export CuVec
 module CuVec
 using ..Mocha
 
+using Compat
+
 const THREADS_PER_BLOCK = 128
 function cuda_geometry(len::Int)
   x_block = round(Int64, ceil(convert(Float64, len)/THREADS_PER_BLOCK))
@@ -13,8 +15,8 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   for name in [:add, :sub, :mul, :div, :div2]
     @eval begin
       function $(symbol("$(name)!"))(backend::GPUBackend, ::Type{$dtype}, X, Y, len::Int)
-        X = convert(Ptr{Void},X)
-        Y = convert(Ptr{Void},Y)
+        X = Compat.unsafe_convert(Ptr{Void},X)
+        Y = Compat.unsafe_convert(Ptr{Void},Y)
         cuda_dim = cuda_geometry(len)
         kernel = backend.mocha.$(symbol("elem_$(name)_$ctype"))
         CUDA.launch(kernel, cuda_dim..., (X, Y, len))
@@ -25,7 +27,7 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   # define add_scal!
   @eval begin
     function add_scal!(backend::GPUBackend, ::Type{$dtype}, X, Y, len::Int)
-      X = convert(Ptr{Void}, X)
+      X = Compat.unsafe_convert(Ptr{Void}, X)
       Y = convert($dtype, Y)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("add_scal_$ctype"))
@@ -36,7 +38,7 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   # define log!
   @eval begin
     function log!(backend::GPUBackend, ::Type{$dtype}, X, len::Int)
-      X = convert(Ptr{Void}, X)
+      X = Compat.unsafe_convert(Ptr{Void}, X)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("elem_log_$ctype"))
       CUDA.launch(kernel, cuda_dim..., (X,len))
@@ -46,7 +48,7 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   # define mul_scal!
   @eval begin
     function mul_scal!(backend::GPUBackend, ::Type{$dtype}, X, Y, len::Int)
-      X = convert(Ptr{Void}, X)
+      X = Compat.unsafe_convert(Ptr{Void}, X)
       Y = convert($dtype, Y)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("mul_scal_$ctype"))
@@ -82,7 +84,7 @@ for (postfix, dt1, dt2) in [(:fi, Float32, Int), (:di, Float64, Int),
                             (:ff, Float32, Float32), (:dd, Float64, Float64)]
   @eval begin
     function pow!(backend::GPUBackend, ::Type{$dt1}, X, Y::$dt2, len::Int)
-      X = convert(Ptr{Void}, X)
+      X = Compat.unsafe_convert(Ptr{Void}, X)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("elem_pow_$postfix"))
       CUDA.launch(kernel, cuda_dim..., (X,Y,len))

--- a/src/cuda/utils/math.jl
+++ b/src/cuda/utils/math.jl
@@ -4,7 +4,7 @@ using ..Mocha
 
 const THREADS_PER_BLOCK = 128
 function cuda_geometry(len::Int)
-  x_block = round(Int64, ceil(float64(len)/THREADS_PER_BLOCK))
+  x_block = round(Int64, ceil(Float64(len)/THREADS_PER_BLOCK))
   return (x_block, THREADS_PER_BLOCK)
 end
 

--- a/src/cuda/utils/math.jl
+++ b/src/cuda/utils/math.jl
@@ -4,7 +4,7 @@ using ..Mocha
 
 const THREADS_PER_BLOCK = 128
 function cuda_geometry(len::Int)
-  x_block = round(Int64, ceil(Float64(len)/THREADS_PER_BLOCK))
+  x_block = round(Int64, ceil(convert(Float64, len)/THREADS_PER_BLOCK))
   return (x_block, THREADS_PER_BLOCK)
 end
 

--- a/src/layers/convolution.jl
+++ b/src/layers/convolution.jl
@@ -197,7 +197,7 @@ function forward(backend::CPUBackend, state::ConvolutionLayerState, inputs::Vect
       for g = 1:state.layer.n_group
         RawBLAS.gemm!('N', 'N', state.etc.M, state.etc.N, state.etc.K, convert(dtype, 1),
             col_buffer + col_offset * (g-1),
-            convert(Ptr{dtype}, pointer(state.filter.data)) + weight_offset * (g-1),
+            Compat.unsafe_convert(Ptr{dtype}, pointer(state.filter.data)) + weight_offset * (g-1),
             convert(dtype, 0), output_ptr + top_offset * (g-1))
       end
       RawBLAS.gemm!('N', 'N', state.etc.M, state.layer.n_filter, 1, convert(dtype, 1),
@@ -243,7 +243,7 @@ function backward(backend::CPUBackend, state::ConvolutionLayerState, inputs::Vec
           RawBLAS.gemm!('T', 'N', state.etc.K, state.etc.N, state.etc.M, convert(dtype, 1),
               col_buffer + col_offset * (g-1),
               top_diff_ptr + top_offset * (g-1), convert(dtype, 1),
-              convert(Ptr{dtype}, pointer(state.∇filter.data)) + weight_offset * (g-1))
+              Compat.unsafe_convert(Ptr{dtype}, pointer(state.∇filter.data)) + weight_offset * (g-1))
         end
       end
     end


### PR DESCRIPTION
Here are some changes for Julia v0.4.0-rc1, checked on both v0.4 and v0.3, CPU and GPU.

One note, I have been getting sporadic test failures in GPU mode on one of the new layers. When it does happen (not every time), the error is occuring here:
```
ERROR: test failed: -eps < state.loss - expected_loss < eps
 in error at error.jl:21 (repeats 2 times)
while loading C:\Users\droidicus\.julia\v0.3\Mocha\test\layers/binary-cross-entropy-loss.jl, in expression starting on line 73
while loading C:\Users\droidicus\.julia\v0.3\Mocha\test\runtests.jl, in expression starting on line 84
```

I don't think this is due to these changes, but I wanted to point it out in case there is a subtle bug in this pull request.