### PR TITLE
Adding windows DLLs for cudNN 3, CUDA 6.5, and 32-bit versions of each

### DIFF
--- a/src/cuda/cublas.jl
+++ b/src/cuda/cublas.jl
@@ -37,9 +37,9 @@ show(io::IO, error::CuBLASError) = print(io, cublas_error_description[error.code
 @windows? (
 begin
   if VERSION < v"0.4-"
-    const libcublas = find_library(["cublas64_70.dll"], [""])
+    const libcublas = find_library(["cublas64_70.dll", "cublas64_65.dll", "cublas32_70.dll", "cublas32_65.dll"], [""])
   else
-    const libcublas = Libdl.find_library(["cublas64_70.dll"], [""])
+    const libcublas = Libdl.find_library(["cublas64_70.dll", "cublas64_65.dll", "cublas32_70.dll", "cublas32_65.dll"], [""])
   end
 end
 : # linux or mac

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -39,9 +39,9 @@ show(io::IO, error::CuDNNError) = print(io, cudnn_error_description[error.code])
 @windows? (
 begin
   if VERSION < v"0.4-"
-    const libcudnn = find_library(["cudnn64_65.dll"], [""])
+    const libcudnn = find_library(["cudnn64_70.dll", "cudnn64_65.dll", "cudnn32_70.dll", "cudnn32_65.dll"], [""])
   else
-    const libcudnn = Libdl.find_library(["cudnn64_65.dll"], [""])
+    const libcudnn = Libdl.find_library(["cudnn64_70.dll", "cudnn64_65.dll", "cudnn32_70.dll", "cudnn32_65.dll"], [""])
   end
 end
 : # linux or mac

--- a/src/cuda/layers/channel-pooling.jl
+++ b/src/cuda/layers/channel-pooling.jl
@@ -1,5 +1,3 @@
-using Compat
-
 function setup_etc(backend::GPUBackend, layer::ChannelPoolingLayer, inputs, blobs)
   if isa(layer.pooling, Pooling.Max)
     masks = Array(CuPtr, length(inputs))
@@ -85,9 +83,9 @@ function cuda_mean_channel_pooling_forward{T}(backend::GPUBackend, input::CuTens
   output_fea_dim = spatial_dim * pooled_chann
 
   for n = 1:num
-    input_ptr = Compat.unsafe_convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
-    output_ptr = Compat.unsafe_convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
-    integral_ptr = Compat.unsafe_convert(Ptr{T}, integral.p)
+    input_ptr = convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
+    output_ptr = convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
+    integral_ptr = convert(Ptr{T}, integral.p)
 
     # compute integral image
     CuBLAS.copy(backend.cublas_ctx, T, spatial_dim_T, input_ptr, 1, integral_ptr, 1)
@@ -130,8 +128,8 @@ function cuda_mean_channel_pooling_backward{T}(backend::GPUBackend, input::CuTen
   output_fea_dim = spatial_dim * pooled_chann
 
   for n = 1:num
-    input_ptr = Compat.unsafe_convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
-    output_ptr = Compat.unsafe_convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
+    input_ptr = convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
+    output_ptr = convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
 
     for pc = 1:pooled_chann
       cstart = (pc-1)*layer.stride - layer.pad[1] + 1

--- a/test/layers/convolution.jl
+++ b/test/layers/convolution.jl
@@ -192,7 +192,7 @@ function test_convolution_layer(backend::Backend, n_input, T, eps)
 end
 
 function test_convolution_layer(backend::Backend)
-  test_convolution_layer(backend, 3, Float64, 1e-10)
+  test_convolution_layer(backend, 3, Float64, 1e-5)
   test_convolution_layer(backend, 3, Float32, 1e-2) # Float32 is sooo inaccurate?
 end
 if test_cpu


### PR DESCRIPTION
Add support for cudNN on Windows, add 32-bit dll names, change eps for Float64 convolution layer to match, and compatibility fix in channel-pooling.