### PR TITLE
Reverting changes to convert()

### DIFF
--- a/src/cuda/cublas.jl
+++ b/src/cuda/cublas.jl
@@ -95,7 +95,7 @@ end
 function set_vector{T}(src::Array{T}, incx::Int, dest::CuPtr, incy::Int)
   elem_size = sizeof(T)
   n = length(src)
-  src_buf = Compat.unsafe_convert(Ptr{Void}, pointer(src))
+  src_buf = convert(Ptr{Void}, pointer(src))
   set_vector(n, elem_size, src_buf, incx, dest, incy)
 end
 set_vector{T}(src::Array{T}, dest::CuPtr) = set_vector(src, 1, dest, 1)
@@ -110,7 +110,7 @@ end
 function get_vector{T}(src::CuPtr, incx::Int, dest::Array{T}, incy::Int)
   elem_size = sizeof(T)
   n = length(dest)
-  dest_buf = Compat.unsafe_convert(Ptr{Void}, pointer(dest))
+  dest_buf = convert(Ptr{Void}, pointer(dest))
   get_vector(n, elem_size, src, incx, dest_buf, incy)
 end
 get_vector{T}(src::CuPtr, dest::Array{T}) = get_vector(src, 1, dest, 1)

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -182,7 +182,7 @@ immutable CuStream
 end
 
 function null_stream()
-  CuStream(Compat.unsafe_convert(Ptr{Void}, 0), true, 0)
+  CuStream(convert(Ptr{Void}, 0), true, 0)
 end
 
 function destroy(s::CuStream)

--- a/src/cuda/layers/binary-cross-entropy-loss.jl
+++ b/src/cuda/layers/binary-cross-entropy-loss.jl
@@ -49,7 +49,7 @@ function backward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, 
     error("Unsupported data type $data_type")
   end
 
-  null_ptr = Compat.unsafe_convert(Ptr{data_type}, 0)
+  null_ptr = convert(Ptr{data_type}, 0)
   grad_pred =  isa(diffs[1], CuTensorBlob) ? diffs[1].ptr.p : null_ptr
   grad_label = isa(diffs[2], CuTensorBlob) ? diffs[2].ptr.p : null_ptr
 

--- a/src/cuda/layers/channel-pooling.jl
+++ b/src/cuda/layers/channel-pooling.jl
@@ -85,6 +85,7 @@ function cuda_mean_channel_pooling_forward{T}(backend::GPUBackend, input::CuTens
   for n = 1:num
     input_ptr = convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
     output_ptr = convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
+
     integral_ptr = convert(Ptr{T}, integral.p)
 
     # compute integral image
@@ -128,8 +129,8 @@ function cuda_mean_channel_pooling_backward{T}(backend::GPUBackend, input::CuTen
   output_fea_dim = spatial_dim * pooled_chann
 
   for n = 1:num
-    input_ptr = convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
-    output_ptr = convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
+    input_ptr = convert(Ptr{T}, input.ptr.p) + fea_dim*(n-1)
+    output_ptr = convert(Ptr{T}, output.ptr.p) + output_fea_dim*(n-1)
 
     for pc = 1:pooled_chann
       cstart = (pc-1)*layer.stride - layer.pad[1] + 1

--- a/src/cuda/layers/channel-pooling.jl
+++ b/src/cuda/layers/channel-pooling.jl
@@ -85,7 +85,6 @@ function cuda_mean_channel_pooling_forward{T}(backend::GPUBackend, input::CuTens
   for n = 1:num
     input_ptr = convert(Ptr{T}, input.ptr.p + fea_dim*(n-1))
     output_ptr = convert(Ptr{T}, output.ptr.p + output_fea_dim*(n-1))
-
     integral_ptr = convert(Ptr{T}, integral.p)
 
     # compute integral image

--- a/src/cuda/layers/hdf5-data.jl
+++ b/src/cuda/layers/hdf5-data.jl
@@ -1,6 +1,6 @@
 function set_blob_data{T}(data::Array{T}, blob::CuTensorBlob{T}, blob_idx::Int)
   n_fea = get_fea_size(blob)
   ptr = Compat.unsafe_convert(Ptr{Void}, blob.ptr.p) + sizeof(T) * n_fea * (blob_idx-1) # note 0-based indexing in CUDA Vector
-  CuBLAS.set_vector(length(data), sizeof(T), Compat.unsafe_convert(Ptr{Void},pointer(data)), 1, ptr, 1)
+  CuBLAS.set_vector(length(data), sizeof(T), convert(Ptr{Void},pointer(data)), 1, ptr, 1)
 end
 

--- a/src/cuda/layers/multinomial-logistic-loss.jl
+++ b/src/cuda/layers/multinomial-logistic-loss.jl
@@ -20,7 +20,7 @@ function forward(backend::GPUBackend, state::MultinomialLogisticLossLayerState, 
   end
 
   if isa(state.weights_blob, NullBlob)
-    weights = Compat.unsafe_convert(Ptr{data_type}, 0)
+    weights = convert(Ptr{data_type}, 0)
   else
     weights = state.weights_blob.ptr.p
   end

--- a/src/cuda/layers/softmax-loss.jl
+++ b/src/cuda/layers/softmax-loss.jl
@@ -11,7 +11,7 @@ function backward(backend::GPUBackend, state::SoftmaxLossLayerState, inputs::Vec
     y_block = spatial_dim
 
     if isa(state.logistic.weights_blob, NullBlob)
-      weights = Compat.unsafe_convert(Ptr{data_type}, 0)
+      weights = convert(Ptr{data_type}, 0)
     else
       weights = state.logistic.weights_blob.ptr.p
     end

--- a/src/cuda/utils/math.jl
+++ b/src/cuda/utils/math.jl
@@ -2,8 +2,6 @@ export CuVec
 module CuVec
 using ..Mocha
 
-using Compat
-
 const THREADS_PER_BLOCK = 128
 function cuda_geometry(len::Int)
   x_block = round(Int64, ceil(convert(Float64, len)/THREADS_PER_BLOCK))
@@ -15,8 +13,8 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   for name in [:add, :sub, :mul, :div, :div2]
     @eval begin
       function $(symbol("$(name)!"))(backend::GPUBackend, ::Type{$dtype}, X, Y, len::Int)
-        X = Compat.unsafe_convert(Ptr{Void},X)
-        Y = Compat.unsafe_convert(Ptr{Void},Y)
+        X = convert(Ptr{Void},X)
+        Y = convert(Ptr{Void},Y)
         cuda_dim = cuda_geometry(len)
         kernel = backend.mocha.$(symbol("elem_$(name)_$ctype"))
         CUDA.launch(kernel, cuda_dim..., (X, Y, len))
@@ -27,7 +25,7 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   # define add_scal!
   @eval begin
     function add_scal!(backend::GPUBackend, ::Type{$dtype}, X, Y, len::Int)
-      X = Compat.unsafe_convert(Ptr{Void}, X)
+      X = convert(Ptr{Void}, X)
       Y = convert($dtype, Y)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("add_scal_$ctype"))
@@ -38,7 +36,7 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   # define log!
   @eval begin
     function log!(backend::GPUBackend, ::Type{$dtype}, X, len::Int)
-      X = Compat.unsafe_convert(Ptr{Void}, X)
+      X = convert(Ptr{Void}, X)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("elem_log_$ctype"))
       CUDA.launch(kernel, cuda_dim..., (X,len))
@@ -48,7 +46,7 @@ for (ctype, dtype) in [(:float, Float32), (:double, Float64)]
   # define mul_scal!
   @eval begin
     function mul_scal!(backend::GPUBackend, ::Type{$dtype}, X, Y, len::Int)
-      X = Compat.unsafe_convert(Ptr{Void}, X)
+      X = convert(Ptr{Void}, X)
       Y = convert($dtype, Y)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("mul_scal_$ctype"))
@@ -84,7 +82,7 @@ for (postfix, dt1, dt2) in [(:fi, Float32, Int), (:di, Float64, Int),
                             (:ff, Float32, Float32), (:dd, Float64, Float64)]
   @eval begin
     function pow!(backend::GPUBackend, ::Type{$dt1}, X, Y::$dt2, len::Int)
-      X = Compat.unsafe_convert(Ptr{Void}, X)
+      X = convert(Ptr{Void}, X)
       cuda_dim = cuda_geometry(len)
       kernel = backend.mocha.$(symbol("elem_pow_$postfix"))
       CUDA.launch(kernel, cuda_dim..., (X,Y,len))

--- a/src/layers/convolution.jl
+++ b/src/layers/convolution.jl
@@ -197,7 +197,7 @@ function forward(backend::CPUBackend, state::ConvolutionLayerState, inputs::Vect
       for g = 1:state.layer.n_group
         RawBLAS.gemm!('N', 'N', state.etc.M, state.etc.N, state.etc.K, convert(dtype, 1),
             col_buffer + col_offset * (g-1),
-            Compat.unsafe_convert(Ptr{dtype}, pointer(state.filter.data)) + weight_offset * (g-1),
+            convert(Ptr{dtype}, pointer(state.filter.data)) + weight_offset * (g-1),
             convert(dtype, 0), output_ptr + top_offset * (g-1))
       end
       RawBLAS.gemm!('N', 'N', state.etc.M, state.layer.n_filter, 1, convert(dtype, 1),
@@ -243,7 +243,7 @@ function backward(backend::CPUBackend, state::ConvolutionLayerState, inputs::Vec
           RawBLAS.gemm!('T', 'N', state.etc.K, state.etc.N, state.etc.M, convert(dtype, 1),
               col_buffer + col_offset * (g-1),
               top_diff_ptr + top_offset * (g-1), convert(dtype, 1),
-              Compat.unsafe_convert(Ptr{dtype}, pointer(state.∇filter.data)) + weight_offset * (g-1))
+              convert(Ptr{dtype}, pointer(state.∇filter.data)) + weight_offset * (g-1))
         end
       end
     end


### PR DESCRIPTION
I am recommending that the changes I made to convert() -> Compat.convert() be reverted. After digging into the code base, I have realized that the interface to the CUDA libraries will need to be refactored in order to correctly resolve these issues. At the time I proposed these changes I thought they were helping, but I was incorrect, and these changes are actually producing more warnings then they fix.

Sorry!