### PR TITLE
Fix for #117, add Neurons.Exponential()

### DIFF
--- a/docs/user-guide/layers/loss-layer.rst
+++ b/docs/user-guide/layers/loss-layer.rst
@@ -209,15 +209,15 @@ Loss Layers
 .. class:: GaussianKLLossLayer
 
     Given two inputs *mu* and *sigma* of the same size representing the means
-    and variances of a diagonal multivariate Gaussian distribution, the loss
-    is the Kullback-Leibler divergence from that to the standard Gaussian of
+    and standard deviations of a diagonal multivariate Gaussian distribution, the
+    loss is the Kullback-Leibler divergence from that to the standard Gaussian of
     the same dimension.
 
     Used in variational autoencoders, as in `Kingma & Welling 2013 <http://arxiv.org/abs/1312.6114>`_, as a form of regularization.
 
    .. math::
       D_{KL}(\mathcal{N}(\mathbf{\mu}, \mathrm{diag}(\mathbf{\sigma})) \Vert \mathcal{N}(\mathbf{0}, \mathbf{I}) )
-      =  -\frac{1}{2}\left(n\log(2\pi) + \sum_{i=1}^N (\mu_i^2 + \sigma_i^2) \right)
+      =  -\frac{1}{2}\left(\sum_{i=1}^N (\mu_i^2 + \sigma_i^2 - 2\log\sigma_i) - N\right)
 
    .. attribute:: weight
 
@@ -228,4 +228,4 @@ Loss Layers
 
       Should be a vector containing two symbols. The first one specifies the
       name for the mean vector :math:`\mathbf{\mu}`, and the second one
-      the vector of variances :math:`\mathbf{\sigma}`.
+      the vector of standard deviations :math:`\mathbf{\sigma}`.

--- a/docs/user-guide/neuron.rst
+++ b/docs/user-guide/neuron.rst
@@ -59,6 +59,15 @@ unless it is an identity neuron. Layers have an identity neuron by default [1]_.
 
       \frac{dy}{dx} = 4e^{2x}/(e^{2x} + 1)^2 = (1-y^2)
 
+.. class:: Neurons.Exponential
+
+   The exponential function.
+
+   .. math::
+
+      y = exp(x)
+
+
 .. [1] This is actually not true: not all layers in Mocha support neurons. For
    example, data layers currently does not have neurons, but this feature could
    be added by simply adding a neuron property to the data layer type. However,

--- a/src/cuda/backend.jl
+++ b/src/cuda/backend.jl
@@ -97,6 +97,8 @@ end
   elem_pow_dd,
   elem_log_double,
   elem_log_float,
+  elem_exp_double,
+  elem_exp_float,
 
   max_channel_pooling_forward_float,
   max_channel_pooling_forward_double,

--- a/src/cuda/kernels/elementwise.impl
+++ b/src/cuda/kernels/elementwise.impl
@@ -44,6 +44,19 @@ __device__ void elem_log(T *X, int len) {
   X[idx] = log(X[idx] > 1e-20 ? X[idx] : 1e-20);
 }
 
+template <typename T>
+__device__ void elem_exp(T *X, int len) {
+  ELEMWISE_BOUNDS_AND_INDEX;
+  X[idx] = exp(X[idx]);
+}
+
+template <typename T>
+__device__ void elem___expf(T *X, int len) {
+  ELEMWISE_BOUNDS_AND_INDEX;
+  X[idx] = __expf(X[idx]);
+}
+
+
 #define DEF_ELEMWISE_API(NAME) \
   __global__ void elem_ ## NAME ## _float(float *X, float *Y, int len) { \
     elem_##NAME(X, Y, len); \
@@ -94,6 +107,14 @@ __global__ void elem_log_double(double *X, int len) {
 __global__ void elem_log_float(float *X, int len) {
   elem_log(X, len);
 }
+
+__global__ void elem_exp_double(double *X, int len) {
+  elem_exp(X, len);
+}
+__global__ void elem_exp_float(float *X, int len) {
+  elem___expf(X, len);
+}
+
 
 } // extern "C"
 

--- a/src/cuda/layers/gaussian-kl-loss.jl
+++ b/src/cuda/layers/gaussian-kl-loss.jl
@@ -1,5 +1,14 @@
 
-const log2π = log(2π)
+function setup(backend::GPUBackend, layer::GaussianKLLossLayer, inputs::Vector{Blob}, diffs::Vector{Blob})
+  data_type = eltype(inputs[1])
+  aux_ones = make_blob(backend, data_type, size(inputs[2])...) # for summing
+  fill!(aux_ones, 1.0)
+  tmp = make_blob(backend, data_type, size(inputs[2])...)
+  state = GaussianKLLossLayerState(layer, zero(data_type), zero(data_type), 0,
+                                   Dict(:aux_ones => aux_ones, :tmp => tmp))
+  return state
+end
+
 
 function forward(backend::GPUBackend, state::GaussianKLLossLayerState, inputs::Vector{Blob})
   mu  = inputs[1]
@@ -8,11 +17,22 @@ function forward(backend::GPUBackend, state::GaussianKLLossLayerState, inputs::V
   data_type = eltype(mu)
   n = length(mu) # length or num?
 
+  aux_ones  = state.tmp_blobs[:aux_ones]
+  log_sigma_tmp = state.tmp_blobs[:tmp]
+  copy!(log_sigma_tmp, sigma)
+  CuVec.log!(backend, log_sigma_tmp)
 
-  Σμ² = CuBLAS.dot(backend.cublas_ctx, data_type, n, mu.ptr, 1, mu.ptr, 1)
-  Σσ² = CuBLAS.dot(backend.cublas_ctx, data_type, n, sigma.ptr, 1, sigma.ptr, 1)
+  Σμ²  = CuBLAS.dot(backend.cublas_ctx, data_type, n, mu.ptr, 1, mu.ptr, 1)
+  Σσ²  = CuBLAS.dot(backend.cublas_ctx, data_type, n, sigma.ptr, 1, sigma.ptr, 1)
+  logΣ = CuBLAS.dot(backend.cublas_ctx, data_type, n, log_sigma_tmp.ptr, 1, aux_ones.ptr, 1)
+  state.loss = 0.5(Σμ² + Σσ² - 2logΣ - n) * state.layer.weight / num
 
-  state.loss = -0.5(n * log2π + Σμ² + Σσ²) * -state.layer.weight / num
+  # accumulate statistics
+  state.loss_accum *= state.n_accum
+  state.loss_accum += state.loss * n
+  state.loss_accum /= state.n_accum + n
+
+  state.n_accum += n
 end
 
 
@@ -22,17 +42,24 @@ function backward(backend::GPUBackend, state::GaussianKLLossLayerState, inputs::
   sigma = inputs[2]
   data_type = eltype(mu)
   num = get_num(mu)
-    #diff = df/dmu[i]
+
+  # diff = df/dmu[i] = mu
   diff = diffs[1]
   if isa(diff, CuTensorBlob)
     copy!(diff, mu)
     CuVec.mul_scal!(backend, diff, convert(data_type, state.layer.weight/num))
   end
 
-    #diff = df/dsigma[i]
+  # diff = df/dsigma[i] = sigma - 1/sigma
   diff = diffs[2]
+
+  tmp = state.tmp_blobs[:tmp]
+  copy!(tmp, sigma)
   if isa(diff, CuTensorBlob)
     copy!(diff, sigma)
+    copy!(tmp, sigma)
+    CuVec.pow!(backend, tmp, convert(data_type, -1.0))
+    CuVec.sub!(backend, diff, tmp)
     CuVec.mul_scal!(backend, diff, convert(data_type, state.layer.weight/num))
   end
 end

--- a/src/cuda/neurons.jl
+++ b/src/cuda/neurons.jl
@@ -117,3 +117,13 @@ function backward(backend :: GPUBackend, neuron :: Neurons.Tanh, output :: Blob,
   CUDA.launch(kernel, cuda_dim..., tuple(output.ptr.p, gradient.ptr.p, blob_dim...))
 end
 
+
+## Exponential
+
+function forward(backend :: GPUBackend, neuron :: Neurons.Exponential, output :: Blob)
+  CuVec.exp!(backend, output)
+end
+
+function backward(backend :: GPUBackend, neuron :: Neurons.Exponential, output :: Blob, gradient :: Blob)
+  CuVec.mul!(backend, gradient, output)
+end

--- a/src/layers/gaussian-kl-loss.jl
+++ b/src/layers/gaussian-kl-loss.jl
@@ -7,8 +7,6 @@
 # to the standard Gaussian N(0,I).
 ############################################################
 
-using Devectorize
-
 @defstruct GaussianKLLossLayer Layer (
                                       name :: String = "gauss-kl-loss",
                                       (weight :: FloatingPoint = 1.0, weight >= 0),
@@ -95,7 +93,7 @@ function backward(backend::CPUBackend, state::GaussianKLLossLayerState,
 
   if isa(diffs[2], CPUBlob)
     sigma_diffs = diffs[2].data
-    @devec sigma_diffs[:] = sigma - (1 ./ sigma)
+    sigma_diffs[:] = sigma - (1 ./ sigma)
     diffs[2].data[:] *= state.layer.weight / n
   end
 end

--- a/src/layers/gaussian-kl-loss.jl
+++ b/src/layers/gaussian-kl-loss.jl
@@ -6,62 +6,96 @@
 # Kullback-Leibler divergence from the input distribution
 # to the standard Gaussian N(0,I).
 ############################################################
-@defstruct GaussianKLLossLayer Layer (
-  name :: String = "gauss-kl-loss",
-  (weight :: FloatingPoint = 1.0, weight >= 0),
-  (bottoms :: Vector{Symbol} = Symbol[:mu, :sigma], length(bottoms) == 2),
-)
-@characterize_layer(GaussianKLLossLayer,
-  has_loss  => true,
-  can_do_bp => true,
-  is_sink   => true,
-)
 
-type GaussianKLLossLayerState{T} <: LayerState
+using Devectorize
+
+@defstruct GaussianKLLossLayer Layer (
+                                      name :: String = "gauss-kl-loss",
+                                      (weight :: FloatingPoint = 1.0, weight >= 0),
+                                      (bottoms :: Vector{Symbol} = Symbol[:mu, :sigma], length(bottoms) == 2),
+                                      )
+
+@characterize_layer(GaussianKLLossLayer,
+                    has_loss  => true,
+                    can_do_bp => true,
+                    is_sink   => true,
+                    has_stats => true,
+                    )
+
+type GaussianKLLossLayerState{T, B<:Blob} <: LayerState
   layer      :: GaussianKLLossLayer
   loss       :: T
+  loss_accum :: T
+  n_accum    :: Int
+
+  tmp_blobs :: Dict{Symbol, B}
 end
 
-function setup(backend::Backend, layer::GaussianKLLossLayer, inputs::Vector{Blob}, diffs::Vector{Blob})
-  data_type = eltype(inputs[1])
 
-  state = GaussianKLLossLayerState(layer, zero(data_type))
+function setup(backend::CPUBackend, layer::GaussianKLLossLayer, inputs::Vector{Blob}, diffs::Vector{Blob})
+  data_type = eltype(inputs[1])
+  state = GaussianKLLossLayerState(layer, zero(data_type), zero(data_type), 0, Dict{Symbol, CPUBlob}())
   return state
 end
+
 function shutdown(backend::Backend, state::GaussianKLLossLayerState)
-    # nothing
+  for blob in values(state.tmp_blobs)
+    destroy(blob)
+  end
 end
 
-const log2π = log(2π)
+function reset_statistics(state::GaussianKLLossLayerState)
+  state.n_accum = 0
+  state.loss_accum = zero(typeof(state.loss_accum))
+end
 
+function dump_statistics(storage, state::GaussianKLLossLayerState, show::Bool)
+  update_statistics(storage, "$(state.layer.name)-encoder-loss", state.loss_accum)
+
+  if show
+    loss = @sprintf("%.4f", state.loss_accum)
+    @info("  GaussianKL-loss (avg over $(state.n_accum)) = $loss")
+  end
+end
 
 function forward(backend::CPUBackend, state::GaussianKLLossLayerState, inputs::Vector{Blob})
-  mu  = inputs[1]
-  sigma = inputs[2]
+  data_type = eltype(inputs[1])
+  n = get_num(inputs[1])
+  nn = length(inputs[1])
+  mu = inputs[1].data
 
-  data_type = eltype(mu)
-  n = length(mu) # length or num?
-  num = get_num(mu)
-  #@assert length(sigma) == n
-  state.loss = -0.5(n * log2π  + sum(mu.data.^2 + sigma.data.^2)) * -state.layer.weight / num
-#    @info("KL fwd: got μ=$(mu.data), σ=$(sigma.data), loss = $(state.loss)")
+  sigma = inputs[2].data
+
+  state.loss = zero(data_type)
+  for i in 1:nn
+    state.loss += mu[i]^2 + sigma[i]^2 - 2log(sigma[i]) - 1
+  end
+  state.loss *= 0.5 * state.layer.weight / n
+
+  # accumulate statistics
+  state.loss_accum *= state.n_accum
+  state.loss_accum += state.loss * n
+  state.loss_accum /= state.n_accum + n
+
+  state.n_accum += n
 end
 
-function backward(backend::CPUBackend, state::GaussianKLLossLayerState, inputs::Vector{Blob}, diffs::Vector{Blob})
-  num = get_num(inputs[1])
-  diff = diffs[1]
-  #diff = df/dmu[i]
+function backward(backend::CPUBackend, state::GaussianKLLossLayerState,
+                  inputs::Vector{Blob}, diffs::Vector{Blob})
+  data_type = eltype(inputs[1])
+  n = get_num(inputs[1])
+  nn = length(inputs[1])
+  mu = inputs[1].data
+  sigma = inputs[2].data
 
-  if isa(diff, CPUBlob)
-    mu    = inputs[1].data
-    copy!(diff, mu*state.layer.weight/num)
+  if isa(diffs[1], CPUBlob)
+    diffs[1].data[:] = mu
+    diffs[1].data[:] *= state.layer.weight / n
   end
 
-  diff = diffs[2]
-  #diff = df/dsigma[i]
-  if isa(diff, CPUBlob)
-    sigma = inputs[2].data
-    copy!(diff, sigma*state.layer.weight/num)
+  if isa(diffs[2], CPUBlob)
+    sigma_diffs = diffs[2].data
+    @devec sigma_diffs[:] = sigma - (1 ./ sigma)
+    diffs[2].data[:] *= state.layer.weight / n
   end
-
 end

--- a/src/neurons.jl
+++ b/src/neurons.jl
@@ -35,7 +35,11 @@ end
 type ReLU <: ActivationFunction
 end
 
-# Leaky Rectified-Linear: LReLU(x) = x > 0 ? x : 0.01x 
+# Exponential: Exponential(x) = exp(x)
+type Exponential <: ActivationFunction
+end
+
+# Leaky Rectified-Linear: LReLU(x) = x > 0 ? x : 0.01x
 type LReLU <: ActivationFunction
 end
 
@@ -116,5 +120,23 @@ function backward(backend :: CPUBackend, neuron :: Neurons.Tanh, output :: Blob,
   len = length(output)
   @simd for i = 1:len
     @inbounds gradient.data[i] *= (1 - output.data[i] * output.data[i])
+  end
+end
+
+
+
+############################################################
+# Exponential
+############################################################
+function forward(backend :: CPUBackend, neuron :: Neurons.Exponential, output :: Blob)
+  len = length(output)
+  @simd for i = 1:len
+    @inbounds output.data[i] = exp(output.data[i])
+  end
+end
+function backward(backend :: CPUBackend, neuron :: Neurons.Exponential, output :: Blob, gradient :: Blob)
+  len = length(output)
+  @simd for i = 1:len
+    @inbounds gradient.data[i] *= output.data[i]
   end
 end

--- a/test/neurons/exponential.jl
+++ b/test/neurons/exponential.jl
@@ -1,0 +1,36 @@
+function test_exponential_neuron(backend::Backend, T, eps)
+  println("-- Testing Exponential neuron on $(typeof(backend)){$T}...")
+
+  data = rand(T, 3,4,5,6) - 0.5
+  data_blob = make_blob(backend, data)
+  neuron = Neurons.Exponential()
+
+  println("    > Forward")
+  forward(backend, neuron, data_blob)
+  expected_data = exp(data)
+  got_data = zeros(T, size(data))
+  copy!(got_data, data_blob)
+
+  @test all(-eps .< got_data - expected_data .< eps)
+
+  println("    > Backward")
+  grad = rand(T, size(data))
+  grad_blob = make_blob(backend, grad)
+  backward(backend, neuron, data_blob, grad_blob)
+
+  expected_grad = grad .* expected_data
+  got_grad = zeros(T, size(expected_grad))
+  copy!(got_grad, grad_blob)
+  @test all(-eps .< got_grad - expected_grad .< eps)
+end
+function test_exponential_neuron(backend::Backend)
+  test_exponential_neuron(backend, Float32, 1e-3)
+  test_exponential_neuron(backend, Float64, 1e-9)
+end
+
+if test_cpu
+  test_exponential_neuron(backend_cpu)
+end
+if test_gpu
+  test_exponential_neuron(backend_gpu)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ end
 include("neurons/relu.jl")
 include("neurons/sigmoid.jl")
 include("neurons/tanh.jl")
+include("neurons/exponential.jl")
 
 ############################################################
 # Regularizers


### PR DESCRIPTION
This corrects the GaussianKLLossLayer problem that @jeff-regier spotted.  That in turn means the MNIST VAE example can no longer safely use ReLU activations (because they can produce zero outputs that now cause log(0) in GaussianKLLossLayer) so I have also added Neurons.Exponential() which is just the exp(x) activation function.