### PR TITLE
Use destroy() not CUDA.free

### DIFF
--- a/src/cuda/layers/dropout.jl
+++ b/src/cuda/layers/dropout.jl
@@ -26,7 +26,7 @@ end
 function destroy_etc(backend::GPUBackend, state::DropoutLayerState)
   cuda_rand_states, input_copy = state.etc
   CUDA.free(cuda_rand_states)
-  CUDA.free(input_copy)
+  destroy(input_copy)
 end
 
 function forward(backend::GPUBackend, state::DropoutLayerState, inputs::Vector{Blob})


### PR DESCRIPTION
This is causing test/layers/dropout.jl to fail for me.