### PR TITLE
Added types to missing method errors

### DIFF
--- a/docs/dev-guide/layer.rst
+++ b/docs/dev-guide/layer.rst
@@ -31,7 +31,7 @@ example
 .. code-block:: julia
 
    @defstruct PoolingLayer Layer (
-     name :: String = "pooling",
+     name :: AbstractString = "pooling",
      (bottoms :: Vector{Symbol} = Symbol[], length(bottoms) > 0),
      (tops :: Vector{Symbol} = Symbol[], length(tops) == length(bottoms)),
      (kernel :: NTuple{2, Int} = (1,1), all([kernel...] .> 0)),
@@ -228,4 +228,3 @@ Layer Activation Function
 When it makes sense for a layer to have an activation function, it can add
 a ``neuron`` property to the ``Layer`` object and define the ``has_neuron``
 characterization. Everything else will be handled automatically.
-

--- a/src/layers/hinge-loss.jl
+++ b/src/layers/hinge-loss.jl
@@ -4,8 +4,8 @@
 # L(\hat{y},y) = 1/2N \sum_{i=1}^N (1-y_i \hat{y}_i)
 #########################################################
 @defstruct HingeLossLayer Layer (
-    name :: String = "hinge-loss",
-    (weight :: FloatingPoint = 1.0, weight >= 0),
+    name :: AbstractString = "hinge-loss",
+    (weight :: AbstractFloat = 1.0, weight >= 0),
     (bottoms :: Vector{Symbol} = Symbol[], length(bottoms) == 2),
 )
 

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -91,28 +91,28 @@ function format_statistic(state::SolverState, name, value)
 end
 
 
-validate_parameters(method::SolverMethod, params::SolverParameters) = begin
+validate_parameters(method::SolverMethod, params::SolverParameters) = begin # should turn validate method-specific parameters
     validate_parameters(params)
-    error("Not implemented - should turn validate method-specific parameters")
+    error("solver_state is not implemented for the method type $(typeof(method)), and params type $(typeof(params))")
 end
 
-function snapshot(state::SolverState)
-    error("Not implemented - should turn a SolverState{T] into a SolverStateSnapshot instance")
+function snapshot(state::SolverState) # should turn a SolverState{T} into a SolverStateSnapshot instance
+    error("snapshot is not implemented for the state type $(typeof(state))")
 end
 
-function solver_state(net::Net, snapshot::SolverStateSnapshot)
-    error("Not implemented - should use a SolverStateSnapshot instance to create a SolverState{T]")
+function solver_state(net::Net, snapshot::SolverStateSnapshot) # should use a SolverStateSnapshot instance to create a SolverState{T}
+    error("solver_state is not implemented for the net type $(typeof(net)), and snapshot type $(typeof(snapshot))")
 end
 
-function solver_state(solver::SolverMethod, net::Net, params::SolverParameters)
-    error("Not implemented - should create SolverState{T] from SolverParameters dictionary")
+function solver_state(solver::SolverMethod, net::Net, params::SolverParameters) # should create SolverState{T} from SolverParameters dictionary
+    error("solver_state is not implemented for the solver type $(typeof(solver)), net type $(typeof(net)), and params type $(typeof(params))")
 end
 
-function update{T}(solver::Solver{T}, net::Net, state::SolverState)
-  error("Not implemented, should do one iteration of update")
+function update{T}(solver::Solver{T}, net::Net, state::SolverState) # should do one iteration of update
+    error("update is not implemented for the solver type $(typeof(solver)), net type $(typeof(net)), and state type $(typeof(state))")
 end
-function shutdown(state::SolverState)
-  error("Not implemented, should shutdown the solver")
+function shutdown(state::SolverState) # should shutdown the solver
+    error("shutdown is not implemented for the $(typeof(state)) type")
 end
 
 

--- a/tools/image-classifier.jl
+++ b/tools/image-classifier.jl
@@ -51,7 +51,7 @@ end
 ################################################################################
 #-- Classify a single image via filename
 function classify(classifier::ImageClassifier, filename::AbstractString)
-  results = classify(classifier, String[filename])
+  results = classify(classifier, AbstractString[filename])
   return results[1]
 end
 


### PR DESCRIPTION
These errors come up when trying to load a state into a new network solver from a file created with a different solver algorithm. By adding the types into the error messages it helps identify what the problem is.