### PR TITLE
Some small tweaks I've found handy

### DIFF
--- a/src/blob.jl
+++ b/src/blob.jl
@@ -167,3 +167,5 @@ function randn!(a::Array{Float32})
     # https://github.com/JuliaLang/julia/issues/9836
     @compat a[:] = map(Float32, randn(size(a)))
 end
+
+asarray{T}(blob::CPUBlob{T}) = blob.data

--- a/src/cuda/blob.jl
+++ b/src/cuda/blob.jl
@@ -52,3 +52,9 @@ function destroy(blob :: CuTensorBlob)
   end
 end
 
+# Helper function to copy blob to arrays for testing
+function asarray{T}(blob::CuTensorBlob{T})
+  arr = zeros(T, blob.shape)
+  copy!(arr, blob)
+  return arr
+end

--- a/src/net.jl
+++ b/src/net.jl
@@ -152,8 +152,10 @@ function forward(net::Net, regu_coef :: AbstractFloat = 0.0)
         forward(net.backend, net.layers[i].neuron, blob)
       end
     end
-
     if has_loss(net.layers[i])
+      if isnan(net.states[i].loss)
+        error("Got NaN in loss for layer $i, $(net.layers[i].name)")
+      end
       obj_val += net.states[i].loss
     end
 


### PR DESCRIPTION
Here are three small independent changes that I've found useful, I'm happy to discuss or change them as needed.

asarray() is just a helper function to copy out blobs when writing tests, etc.

Raising errors as soon as we encounter NaNs in the objective is useful, the output is useless after that but if we raise an error immediately, it's easier to debug where the problem originated by inspecting the network state.

forward_from() is the most complicated - on reflection it probably needs some documentation to be widely useful to others.  It's a function you can use with a trained network, feeding in the inputs directly to some layer and observing the output.  It lets you use batch sizes smaller than that the network was trained with.  My use case is for inspecting network behaviour interactively, e.g. with Interact.jl - it's a more general version of the make_latent_to_output function I used in the mnist VAE example notebook.  Do we want a feature like this in Mocha? 
