### PR TITLE
Specify julia version explicitly for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.3
+  - 0.4
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
To ensure backward compatiblity for v0.3, `release` is actually ambiguous since it might be changed to v0.4.