### PR TITLE
Fix typos and version number to check for blasfunc compatibility.

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -4,14 +4,14 @@ if VERSION < v"0.3.3"
   function blasfunc(name::Symbol)
     string(name)
   end
-elseif VERSION < v"0.5.0"
+elseif VERSION < v"0.5.0-dev+1915"
   function blasfunc(name::Symbol)
     Base.blasfunc(name)
   end
 else
   function blasfunc(name::Symbol)
     str_name = string(name)
-    fnc_symb = eval(:(Base.@blasfunc $strname))
+    fnc_symb = eval(:(Base.@blasfunc $str_name))
     fnc_name = string(fnc_symb)
     return fnc_name
   end

--- a/src/solvers/sgd.jl
+++ b/src/solvers/sgd.jl
@@ -58,7 +58,6 @@ SGDSolverState(net::Net, learning_rate::Float64, momentum::Float64) = begin
     state = param_states[i]
     param_history[i] = [make_zero_blob(net.backend, eltype(x.blob),size(x.blob)...) for x in state.parameters]
   end
-a
   return SGDSolverState(learning_rate, momentum, param_states, param_history, momentum)
 end
 


### PR DESCRIPTION
blasfunc behavior has been changed in commit 57eb9c1e5cba37a522d82e131fde7b664b1aa9fe.
Command `git rev-list v0.4.0..57eb9c1e5cba37a522d82e131fde7b664b1aa9fe --count` returns the numebr of commit since v0.4.0 which is 1915. This allow for testing also with v0.5.0-dev

Typo prevented tests to be run.

Shoud fix #4