### PR TITLE
Added libcudart as an optional cuda library (runtime library)

### DIFF
--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -10,7 +10,7 @@ begin
 end
 : # linux or mac
 begin
-  const libcuda = Libdl.find_library(["libcuda"], [""])
+  const libcuda = Libdl.find_library(["libcuda","libcudart"], [""])
   if isempty(libcuda)
     error("Libcuda not found via Libdl.find_library! Please check installation and ENV configuration")
   end


### PR DESCRIPTION
On a system I'm deploying Mocha to, only the cuda runtime libraries were installed. I ran Pkg.test("Mocha") successfully after adding libcudart to the cuda libraries list, tests failed prior..