### PR TITLE
Update binary-cross-entropy-loss.jl

### DIFF
--- a/src/cuda/layers/binary-cross-entropy-loss.jl
+++ b/src/cuda/layers/binary-cross-entropy-loss.jl
@@ -6,7 +6,7 @@ function forward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, i
   num = get_num(pred)
   dim = length(pred)
 
-  x_block = int(ceil(convert(Float64, dim)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = Int(ceil(convert(Float64, dim)/CUDA.THREADS_PER_BLOCK_X))
 
   loss_blob = make_zero_blob(backend, Float32, 1, 1, 1, 1)
 
@@ -39,7 +39,7 @@ function backward(backend::GPUBackend, state::BinaryCrossEntropyLossLayerState, 
   num = get_num(pred)
   dim = length(pred)
 
-  x_block = int(ceil(convert(Float64, dim)/CUDA.THREADS_PER_BLOCK_X))
+  x_block = Int(ceil(convert(Float64, dim)/CUDA.THREADS_PER_BLOCK_X))
 
   if data_type == Float32
     kernel = backend.mocha.binary_cross_entropy_loss_backward_float


### PR DESCRIPTION
Fixed a compatibility issue that let the tests fail when using CUDA backend.
`int()` is deprecated. Use `Int()` instead.