### PR TITLE
replace isdefined(field_asserts,i) by isassigned

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -56,7 +56,7 @@ macro defstruct(name, super_name, fields)
   type_body = Expr(:block, field_defs...)
 
   # constructor
-  asserts = map(filter(i -> isdefined(field_asserts,i), 1:length(fields))) do i
+  asserts = map(filter(i -> isassigned(field_asserts,i), 1:length(fields))) do i
     :(@assert($(field_asserts[i])))
   end
   construct = Expr(:call, name, field_names...)


### PR DESCRIPTION
As of Julia v0.6, `isdefined(a::Array, i::Int)` will be deprecated in favor of `isassigned(a, i)`. 
This PR allows to remove the deprecation warnings caused by using Mocha in Julia v0.6.