### PR TITLE
Fix headers in dump network script for caffe API change

### DIFF
--- a/tools/dump_network_hdf5.cpp
+++ b/tools/dump_network_hdf5.cpp
@@ -12,7 +12,16 @@
 #include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/io.hpp"
-#include "caffe/vision_layers.hpp"
+#include "caffe/util/hdf5.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/layers/conv_layer.hpp"
+#include "caffe/layers/lrn_layer.hpp"
+#include "caffe/layers/pooling_layer.hpp"
+#include "caffe/layers/relu_layer.hpp"
+#include "caffe/layers/sigmoid_layer.hpp"
+#include "caffe/layers/softmax_layer.hpp"
+#include "caffe/layers/tanh_layer.hpp"
+#include "caffe/layers/inner_product_layer.hpp"
 
 using namespace caffe;  // NOLINT(build/namespaces)
 


### PR DESCRIPTION
A caffe API change refactored `include/caffe/vision_layers.hpp` into
several smaller files.

See bvlc/caffe#3315 for details on the caffe API change.

I used https://github.com/BVLC/caffe/pull/3315/files as a reference for what the older header corresponded to in terms of new headers.

I also had to add `caffe/util/hdf5.hpp` for it to compile, though I don't think that was part of the API change.