### PR TITLE
Update config.jl

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -9,7 +9,7 @@ const use_native_extension_key = "MOCHA_USE_NATIVE_EXT"
 
 parseEnvInt(key; dflt=0) = begin
   try
-    parseint(ENV[key])
+    parse(Int, ENV[key])
   catch
     dflt
   end


### PR DESCRIPTION
`parseint(x)` removed from Base since julia 0.5
use `parse(Int, x)` instead