### PR TITLE
add windows library names for CUDA (cuBLAS) v8 and cuDNN v5

### DIFF
--- a/src/cuda/cublas.jl
+++ b/src/cuda/cublas.jl
@@ -35,7 +35,7 @@ import Base.show
 show(io::IO, error::CuBLASError) = print(io, cublas_error_description[error.code])
 
 if is_windows()
-  const libcublas = Libdl.find_library(["cublas64_70.dll", "cublas64_65.dll",
+  const libcublas = Libdl.find_library(["cublas64_80.dll", "cublas64_70.dll", "cublas64_65.dll",
       "cublas32_70.dll", "cublas32_65.dll", "cublas64_75.dll"], [""])
   @assert (libcublas != "") "Could not find cuBLAS DLL [cublas64_70.dll, cublas64_65.dll, cublas32_70.dll, cublas32_65.dll, cublas64_75.dll]. See: http://mochajl.readthedocs.io/en/latest/user-guide/backend.html#cuda-backend"
 else

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -37,7 +37,7 @@ import Base.show
 show(io::IO, error::CuDNNError) = print(io, cudnn_error_description[error.code])
 
 if is_windows()
-  const libcudnn = Libdl.find_library(["cudnn64_80.dll", "cudnn64_70.dll", "cudnn32_80.dll",
+  const libcudnn = Libdl.find_library(["cudnn64_5.dll", "cudnn64_80.dll", "cudnn64_70.dll", "cudnn32_80.dll",
                                        "cudnn32_70.dll"], [""])
   @assert (libcudnn != "") "Could not find a CUDA neural net DLL [cudnn64_80.dll, cudnn64_70.dll, cudnn32_80.dll, cudnn32_70.dll]. See: http://mochajl.readthedocs.io/en/latest/user-guide/backend.html#cuda-backend"
 else


### PR DESCRIPTION
Thanks for the latest release!
This PR adds the correct library names of CUDA v8 and cuDNN v5 for Windows (10).