### PR TITLE
Memento deprecation fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6
 HDF5 0.7.0
 JLD 0.6.6
 Compat 0.9.5
-Memento
+Memento 0.5

--- a/src/Mocha.jl
+++ b/src/Mocha.jl
@@ -1,5 +1,12 @@
 module Mocha
 
+using Memento
+
+const logger = getlogger(Mocha)
+
+# Necessary for folks to access the logger at runtime via getlogger if Mocha is precompiled
+__init__() = Memento.register(logger)
+
 include("compatibility.jl")
 include("logging.jl")
 include("config.jl")

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,28 +1,28 @@
 using Memento
 export m_debug, m_info, m_notice, m_warn, m_error
 
-remove_handler(get_logger(Mocha), "console")
-add_handler(get_logger(Mocha),
-            DefaultHandler(STDOUT,
-                           DefaultFormatter("[{date} | {level} | {name}]: {msg}")))
-set_level(get_logger(Mocha), "info")
+# NOTE: It isn't generally recommended to configure your logger at the package/library level.
+push!(getlogger(Mocha),
+      DefaultHandler(STDOUT, DefaultFormatter("[{date} | {level} | {name}]: {msg}")))
+setlevel!(getlogger(Mocha), "info")
+setpropagating!(getlogger(Mocha), false)
 
 function m_debug(msg :: AbstractString...)
-  debug(get_logger(Mocha), prod(msg))
+  debug(getlogger(Mocha), prod(msg))
 end
 
 function m_info(msg :: AbstractString...)
-  info(get_logger(Mocha), prod(msg))
+  info(getlogger(Mocha), prod(msg))
 end
 
 function m_notice(msg :: AbstractString...)
-  notice(get_logger(Mocha), prod(msg))
+  notice(getlogger(Mocha), prod(msg))
 end
 
 function m_warn(msg :: AbstractString...)
-  warn(get_logger(Mocha), prod(msg))
+  warn(getlogger(Mocha), prod(msg))
 end
 
 function m_error(msg :: AbstractString...)
-  error(get_logger(Mocha), prod(msg))
+  error(getlogger(Mocha), prod(msg))
 end


### PR DESCRIPTION
Several methods in Memento.jl have been deprecated and we'd like to remove those deprecations in the next release without breaking any packages ([METADATA.jl - #13846](https://github.com/JuliaLang/METADATA.jl/pull/13846#event-1525420971). While we don't recommend configuring loggers inside packages/libraries the following changes will maintain the existing behaviour.